### PR TITLE
Drivers: structure of the package and drivers for DC power source

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
     *i3py/version.py
     */__init__.py
+    *i3py/drivers/
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 omit =
     *i3py/version.py
     */__init__.py
-    *i3py/drivers/
+    *i3py/drivers/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/i3py/core/base_driver.py
+++ b/i3py/core/base_driver.py
@@ -19,7 +19,7 @@ from .abstracts import AbstractBaseDriver
 from .has_features import HasFeatures
 
 
-class InstrumentSigleton(type):
+class InstrumentSingleton(type):
     """Metaclass ensuring that a single driver is created per instrument.
 
     """
@@ -54,7 +54,7 @@ class InstrumentSigleton(type):
         cache = cls._instances_cache[cls]
         driver_id = cls.compute_id(args, kwargs)  # type: ignore
         if driver_id not in cache:
-            dr = super(InstrumentSigleton, cls).__call__(*args, **kwargs)
+            dr = super(InstrumentSingleton, cls).__call__(*args, **kwargs)
 
             cache[driver_id] = dr
         else:
@@ -64,7 +64,7 @@ class InstrumentSigleton(type):
         return dr
 
 
-class BaseDriver(HasFeatures, metaclass=InstrumentSigleton):
+class BaseDriver(HasFeatures, metaclass=InstrumentSingleton):
     """ Base class of all instrument drivers in I3py.
 
     This class defines the common interface drivers are expected to implement

--- a/i3py/core/base_subsystem.py
+++ b/i3py/core/base_subsystem.py
@@ -19,7 +19,7 @@ from .utils import check_options
 
 
 class SubSystem(HasFeatures):
-    """SubSystem allow to split the implementation of a driver into multiple
+    """SubSystem allows one to split the implementation of a driver into multiple
     parts.
 
     This mechanism allow to avoid crowding the instrument namespace with very

--- a/i3py/drivers/__init__.py
+++ b/i3py/drivers/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package storing all the implemented drivers by manufacturer.
+
+The package contains also the standards definitions and common utilities such
+as support for IEEE488 and SCPI commands.
+
+"""

--- a/i3py/drivers/agilent/__init__.py
+++ b/i3py/drivers/agilent/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Alias package for the Keysight package.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+from .. import keysight
+
+sys.modules[__name__] = LazyPackage({}, __name__, __doc__, locals())

--- a/i3py/drivers/alazar_tech/__init__.py
+++ b/i3py/drivers/alazar_tech/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Alazar Tech instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/anritsu/__init__.py
+++ b/i3py/drivers/anritsu/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Anritsu instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/base/dc_sources.py
+++ b/i3py/drivers/base/dc_sources.py
@@ -21,7 +21,7 @@ class DCPowerSource(HasFeatures):
     """
 
     #: Outputs of the source. By default we declare a single output on index 0.
-    output = channel((0,))
+    output = channel((1,))
 
     with output as o:
 
@@ -68,16 +68,16 @@ class DCPowerSource(HasFeatures):
 
             Returns
             -------
-            status : {'constant_voltage', 'constant_current',
-                      'over_voltage', 'over_current', 'unregulated'}
+            status : {'constant-voltage', 'constant-current',
+                      'over-voltage', 'over-current', 'unregulated'}
                 The possible values for the output status are the following.
                 - 'constant_voltage': the target voltage was reached before the
                   target current and voltage_limit_behavior is 'regulate'.
-                - 'constant_current': the target current was reached before the
+                - 'constant-current': the target current was reached before the
                   target voltage and current_limit_behavior is 'regulate'.
-                - 'over_voltage': the output tripped after reaching the
+                - 'over-voltage': the output tripped after reaching the
                   voltage limit.
-                - 'over_current': the output tripped after reaching the
+                - 'over-current': the output tripped after reaching the
                   current limit.
                 - 'unregulated': The output of the instrument is not stable.
 

--- a/i3py/drivers/base/dc_sources.py
+++ b/i3py/drivers/base/dc_sources.py
@@ -21,13 +21,13 @@ class DCPowerSource(HasFeatures):
     """
 
     #: Outputs of the source. By default we declare a single output on index 0.
-    output = channel((0,))
+    outputs = channel((0,))
 
-    with output as o:
+    with outputs as o:
 
         #: Is the output on or off.
         #: Care should be taken that this value may not be up to date if a
-        #: failure occured. To know the current status of the output use
+        #: failure occurred. To know the current status of the output use
         #: read_output_status, this feature only store the target setting.
         o.enabled = Bool(aliases={True: ['On', 'ON', 'On'],
                                   False: ['Off', 'OFF', 'off']})
@@ -104,9 +104,9 @@ class DCPowerSourceWithMeasure(DCPowerSource):
 
     """
     #: Outputs of the source. By default we declare a single output on index 0.
-    output = channel((0,))
+    outputs = channel((0,))
 
-    with output as o:
+    with outputs as o:
 
         @o
         @Action()

--- a/i3py/drivers/base/dc_sources.py
+++ b/i3py/drivers/base/dc_sources.py
@@ -55,8 +55,8 @@ class DCPowerSource(HasFeatures):
         #: Range in which the current can be set.
         o.current_range = Float(unit='A')
 
-        #: How does the source behave if it cannot reach the target voltage
-        #: because it reached the target current first.
+        #: How does the source behave if it cannot reach the target current
+        #: because it reached the target voltage first.
         #: - regulate: we stop at the reached voltage when the target current
         #:             is reached.
         #: - trip: the output is disabled if the voltage reaches or gets

--- a/i3py/drivers/base/dc_sources.py
+++ b/i3py/drivers/base/dc_sources.py
@@ -29,7 +29,7 @@ class DCPowerSource(HasFeatures):
         #: Care should be taken that this value may not be up to date if a
         #: failure occurred. To know the current status of the output use
         #: read_output_status, this feature only store the target setting.
-        o.enabled = Bool(aliases={True: ['On', 'ON', 'On'],
+        o.enabled = Bool(aliases={True: ['On', 'ON', 'on'],
                                   False: ['Off', 'OFF', 'off']})
 
         #: Target voltage for the output. If the source is a "current" source
@@ -40,7 +40,7 @@ class DCPowerSource(HasFeatures):
         o.voltage_range = Float(unit='V')
 
         #: How does the source behave if it cannot reach the target voltage
-        #: because its reached the target current first.
+        #: because it reached the target current first.
         #: - regulate: we stop at the reached voltage when the target current
         #:             is reached.
         #: - trip: the output is disabled if the current reaches or gets
@@ -56,7 +56,7 @@ class DCPowerSource(HasFeatures):
         o.current_range = Float(unit='A')
 
         #: How does the source behave if it cannot reach the target voltage
-        #: because its reached the target current first.
+        #: because it reached the target current first.
         #: - regulate: we stop at the reached voltage when the target current
         #:             is reached.
         #: - trip: the output is disabled if the voltage reaches or gets

--- a/i3py/drivers/base/dc_sources.py
+++ b/i3py/drivers/base/dc_sources.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""I3py standard for DC sources.
+
+"""
+from i3py.core import HasFeatures, SubSystem, channel
+from i3py.core.unit import FLOAT_QUANTITY
+from i3py.core.actions import Action
+from i3py.core.features import Bool, Float, Str, constant
+
+
+class DCPowerSource(HasFeatures):
+    """Standard interface expected from all DC Power sources.
+
+    """
+
+    #: Outputs of the source. By default we declare a single output on index 0.
+    output = channel((0,))
+
+    with output as o:
+
+        #: Is the output on or off. Note that this value does not
+        o.enabled = Bool(aliases={True: ['On', 'ON', 'On'],
+                                  False: ['Off', 'OFF', 'off']})
+
+        #: Target voltage for the output. If the source is a "current" source
+        #: this will likely be a fixed value.
+        o.voltage = Float(unit='V')
+
+        #: Range in which the voltage can be set.
+        o.voltage_range = Float(unit='V')
+
+        #: How does the source behave if it cannot reach the target voltage
+        #: because its reached the target current first.
+        #: - regulate: we stop at the reached voltage when the target current
+        #:             is reached.
+        #: - trip: the output is disabled if the current reaches or gets
+        #:         greater than the specified current.
+        o.current_limit_behavior = Str(constant('regulate'),
+                                       values=('regulate', 'trip'))
+
+        #: Target voltage for the output. If the source is a "voltage" source
+        #: this will likely be a fixed value.
+        o.current = Float(unit='A')
+
+        #: Range in which the current can be set.
+        o.current_range = Float(unit='A')
+
+        #: How does the source behave if it cannot reach the target voltage
+        #: because its reached the target current first.
+        #: - regulate: we stop at the reached voltage when the target current
+        #:             is reached.
+        #: - trip: the output is disabled if the voltage reaches or gets
+        #:         greater than the specified voltage.
+        o.voltage_limit_behavior = Str(constant('regulate'),
+                                       values=('regulate', 'trip'))
+
+        @o
+        @Action()
+        def read_output_status(self) -> str:
+            """Determine the status of the output.
+
+            Returns
+            -------
+            status : {'constant_voltage', 'constant_current',
+                      'over_voltage', 'over_current', 'unregulated'}
+                The possible values for the output status are the following.
+                - 'constant_voltage': the target voltage was reached before the
+                  target current and voltage_limit_behavior is 'regulate'.
+                - 'constant_current': the target current was reached before the
+                  target voltage and current_limit_behavior is 'regulate'.
+                - 'over_voltage': the output tripped after reaching the
+                  voltage limit.
+                - 'over_current': the output tripped after reaching the
+                  current limit.
+                - 'unregulated': The output of the instrument is not stable.
+
+            Notes
+            -----
+            Calling this function is meaningful only if the output is enabled.
+
+            """
+            raise NotImplementedError()
+
+
+class DCPowerSourceWithMeasure(DCPowerSource):
+    """DC power source supporting to measure the output current/voltage.
+
+    """
+    #: Outputs of the source. By default we declare a single output on index 0.
+    output = channel((0,))
+
+    with output as o:
+
+        @o
+        @Action()
+        def measure(self, quantity: str, **kwargs) -> FLOAT_QUANTITY:
+            """Measure the output voltage/current.
+
+            Parameters
+            ----------
+            quantity : str, {'voltage', 'current'}
+                Quantity to measure.
+
+            **kwargs :
+                Optional kwargs to specify the conditions of the measure
+                (integration time, averages, etc) if applicable.
+
+            Returns
+            -------
+            value : float or pint.Quantity
+                Measured value. If units are supported the value is a Quantity
+                object.
+
+            """
+            raise NotImplementedError()
+
+
+# TODO complete once we have a real use for it
+class DCSourceTriggerSubsystem(SubSystem):
+    """Subsystem handing the usual triggering mechanism of DC sources.
+
+    It should be added to a DCPowerSource subclass under the name trigger.
+
+    """
+    #: Working mode for the trigger. This usually defines how the instrument
+    #: will answer to a trigger event.
+    mode = Str(values=('disabled',))
+
+    #: Possible origin for trigger events.
+    source = Str(values=('immediate', 'software'))  # Will extend later
+
+    #: Delay between the trigger and the time at which the instrument start to
+    #: modify its output.
+    delay = Float(unit='s')
+
+    @Action()
+    def arm(self):
+        """Make the system ready to receive a trigger event.
+
+        """
+        pass

--- a/i3py/drivers/base/identity.py
+++ b/i3py/drivers/base/identity.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Standard interface of the identity subsystem.
+
+"""
+from i3py.core.base_subsystem import SubSystem
+from i3py.core.features import Str
+
+
+class Identity(SubSystem):
+    """Standard subsystem defining the expected identity info.
+
+    This should be used as a base class for the identity subsystem of
+    instruments providing identity information.
+
+    Notes
+    -----
+    Some of those info might not be available for a given instrument. In such
+    a case the Feature should return ''.
+
+    """
+    #: Manufacturer as returned by the instrument.
+    manufacturer = Str(True)
+
+    #: Model name as returned by the instrument.
+    model = Str(True)
+
+    #: Instrument serial number.
+    serial = Str(True)
+
+    #: Version of the installed firmware.
+    firmware = Str(True)

--- a/i3py/drivers/common/__init__.py
+++ b/i3py/drivers/common/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Common utility to deal with drivers implementation.
+
+"""
+
+# This package is always needed so there is no point making it lazy

--- a/i3py/drivers/common/ieee488.py
+++ b/i3py/drivers/common/ieee488.py
@@ -207,7 +207,7 @@ class IEEEIdentity(VisaMessageDriver):
             """Get the identity info from the *IDN?.
 
             """
-            infos = Parser(self.IEEE_IDN_FORMAT)(value)
+            infos = Parser(driver.IEEE_IDN_FORMAT)(value)
             driver._cache.update(infos)
             return infos.get(feat.name, '')
 

--- a/i3py/drivers/common/ieee488.py
+++ b/i3py/drivers/common/ieee488.py
@@ -196,7 +196,7 @@ class IEEEIdentity(VisaMessageDriver):
         #: - serial: serial number of the instrument
         #: - firmware: firmware revision
         #: ex {manufacturer},<{model}>,SN{serial}, Firmware revision {firmware}
-        i.IEEE_IDN_FORMAT = ''
+        i.IEEE_IDN_FORMAT = '{manufacturer},{model},{serial},{firmware}'
 
         i.manufacturer = set_feat(getter='*IDN?')
         i.model = set_feat(getter='*IDN?')

--- a/i3py/drivers/common/ieee488.py
+++ b/i3py/drivers/common/ieee488.py
@@ -1,0 +1,498 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Base classes for instruments supporting standards command such *IDN?.
+
+A lot of those class are heavily inspired from the Slave package.
+
+The standards specifies that if one command of a group is implemented all
+commends should be implemented. However this is not always enforced. The
+base classes subdivide a bit more the commands to take this fact into
+account.
+
+Reporting Commands
+ * `*CLS` - Clears the data status structure [#]_ .
+ * `*ESE` - Write the event status enable register [#]_ .
+ * `*ESE?` - Query the event status enable register [#]_ .
+ * `*ESR?` - Query the standard event status register [#]_ .
+ * `*SRE` - Write the status enable register [#]_ .
+ * `*SRE?` - Query the status enable register [#]_ .
+ * `*STB` - Query the status register [#]_ .
+
+Internal operation commands
+ * `*IDN?` - Identification query [#]_ .
+ * `*RST` -  Perform a device reset [#]_ .
+ * `*TST?` - Perform internal self-test [#]_ .
+
+Synchronization commands
+ * `*OPC` - Set operation complete flag high [#]_ .
+ * `*OPC?` -  Query operation complete flag [#]_ .
+ * `*WAI` - Wait to continue [#]_ .
+
+Power on common commands
+ * `*PSC` - Set the power-on status clear bit [#]_ .
+ * `*PSC?` - Query the power-on status clear bit [#]_ .
+
+Parallel poll common commands NOT IMPLEMENTED
+ * `*IST?` - Query the individual status message bit [#]_ .
+ * `*PRE` - Set the parallel poll enable register [#]_ .
+ * `*PRE?` - Query the parallel poll enable register [#]_ .
+
+Resource description common commands
+ * `*RDT` - Store the resource description in the device [#]_ .
+ * `*RDT?` - Query the stored resource description [#]_ .
+
+Protected user data commands
+ * `*PUD` - Store protected user data in the device [#]_ .
+ * `*PUD?` - Query the protected user data [#]_ .
+
+Calibration command
+ * `*CAL?` - Perform internal self calibration [#]_ .
+
+Trigger command
+ * `*TRG` - Execute trigger command [#]_ .
+
+Trigger macro commands
+ * `*DDT` - Define device trigger [#]_ .
+ * `*DDT?` - Define device trigger query [#]_ .
+
+Macro Commands NOT IMPLEMENTED
+ * `*DMC` - Define device trigger [#]_ .
+ * `*EMC` - Define device trigger query [#]_ .
+ * `*EMC?` - Define device trigger [#]_ .
+ * `*GMC?` - Define device trigger query [#]_ .
+ * `*LMC?` - Define device trigger [#]_ .
+ * `*PMC` - Define device trigger query [#]_ .
+
+Option Identification command
+ * `*OPT?` - Option identification query [#]_ .
+
+Stored settings commands
+ * `*RCL` - Restore device settings from local memory [#]_ .
+ * `*SAV` - Store current settings of the device in local memory [#]_ .
+
+Learn command NOT IMPLEMENTED
+ * `*LRN?` - Learn device setup query [#]_ .
+
+System configuration commands NOT IMPLEMENTED
+ * `*AAD` - Accept address command [#]_ .
+ * `*DLF` - Disable listener function command [#]_ .
+
+Passing control command NOT IMPLEMENTED
+ * `*PCB` - Pass control back [#]_ .
+
+Reference:
+
+.. [#] IEC 60488-2:2004(E) section 10.3
+.. [#] IEC 60488-2:2004(E) section 10.10
+.. [#] IEC 60488-2:2004(E) section 10.11
+.. [#] IEC 60488-2:2004(E) section 10.12
+.. [#] IEC 60488-2:2004(E) section 10.34
+.. [#] IEC 60488-2:2004(E) section 10.35
+.. [#] IEC 60488-2:2004(E) section 10.36
+.. [#] IEC 60488-2:2004(E) section 10.14
+.. [#] IEC 60488-2:2004(E) section 10.32
+.. [#] IEC 60488-2:2004(E) section 10.38
+.. [#] IEC 60488-2:2004(E) section 10.18
+.. [#] IEC 60488-2:2004(E) section 10.19
+.. [#] IEC 60488-2:2004(E) section 10.39
+.. [#] IEC 60488-2:2004(E) section 10.25
+.. [#] IEC 60488-2:2004(E) section 10.26
+.. [#] IEC 60488-2:2004(E) section 10.15
+.. [#] IEC 60488-2:2004(E) section 10.23
+.. [#] IEC 60488-2:2004(E) section 10.24
+.. [#] IEC 60488-2:2004(E) section 10.30
+.. [#] IEC 60488-2:2004(E) section 10.31
+.. [#] IEC 60488-2:2004(E) section 10.27
+.. [#] IEC 60488-2:2004(E) section 10.28
+.. [#] IEC 60488-2:2004(E) section 10.2
+.. [#] IEC 60488-2:2004(E) section 10.37
+.. [#] IEC 60488-2:2004(E) section 10.4
+.. [#] IEC 60488-2:2004(E) section 10.5
+.. [#] IEC 60488-2:2004(E) section 10.7
+.. [#] IEC 60488-2:2004(E) section 10.8
+.. [#] IEC 60488-2:2004(E) section 10.9
+.. [#] IEC 60488-2:2004(E) section 10.13
+.. [#] IEC 60488-2:2004(E) section 10.16
+.. [#] IEC 60488-2:2004(E) section 10.22
+.. [#] IEC 60488-2:2004(E) section 10.20
+.. [#] IEC 60488-2:2004(E) section 10.29
+.. [#] IEC 60488-2:2004(E) section 10.33
+.. [#] IEC 60488-2:2004(E) section 10.17
+.. [#] IEC 60488-2:2004(E) section 10.1
+.. [#] IEC 60488-2:2004(E) section 10.6
+.. [#] IEC 60488-2:2004(E) section 10.21
+
+.. _IEC 60488-2: http://dx.doi.org/10.1109/IEEESTD.2004.95390
+
+"""
+from time import sleep
+from typing import ClassVar, Dict
+
+from i3py.backends.visa import VisaMessageDriver
+from i3py.core import subsystem, customize, set_feat
+from i3py.core.actions import Action, RegisterAction
+from i3py.core.features import Bool, Options, Register, Str
+from stringparser import Parser
+
+from ..base.identity import Identity
+
+
+# =============================================================================
+# --- Status reporting --------------------------------------------------------
+# =============================================================================
+
+class IEEEStatusReporting(VisaMessageDriver):
+    """Class implementing the status reporting commands.
+
+    * `*ESE` - See IEC 60488-2:2004(E) section 10.10
+    * `*ESE?` - See IEC 60488-2:2004(E) section 10.11
+    * `*ESR?` - See IEC 60488-2:2004(E) section 10.12
+    * `*SRE` - See IEC 60488-2:2004(E) section 10.34
+    * `*SRE?` - See IEC 60488-2:2004(E) section 10.35
+
+    """
+    #: Define which bits of the status byte cause a service request.
+    service_request_enabled = Register('*SRE?', '*SRE {}')
+
+    #: Define which bits contribute to the event status in the status byte.
+    event_status_enabled = Register('*ESE?', '*ESE {}')
+
+    @RegisterAction(('operation_complete', 'request_control', 'query_error',
+                     'device_dependent_error', 'execution_error',
+                     'command_error', 'user_request', 'power_on',))
+    def read_event_status_register(self) -> int:
+        """Read and clear the event register.
+
+        """
+        return int(self.visa_resource.query('*ESR?'))
+
+
+# =============================================================================
+# --- Internal operations -----------------------------------------------------
+# =============================================================================
+
+class IEEEIdentity(VisaMessageDriver):
+    """Class implementing the identification command.
+
+    The identity susbsytem feature values are extracted by default from the
+    answer to the *IDN? command. Its format can be specified by overriding
+    the idn_format of the subsystem.
+
+    """
+    identity = subsystem(Identity)
+
+    with identity as i:
+
+        #: Format string specifying the format of the IDN query answer and
+        #: allowing to extract the following information:
+        #: - manufacturer: name of the instrument manufacturer
+        #: - model: name of the instrument model
+        #: - serial: serial number of the instrument
+        #: - firmware: firmware revision
+        #: ex {manufacturer},<{model}>,SN{serial}, Firmware revision {firmware}
+        i.IEEE_IDN_FORMAT = ''
+
+        i.manufacturer = set_feat(getter='*IDN?')
+        i.model = set_feat(getter='*IDN?')
+        i.serial = set_feat(getter='*IDN?')
+        i.firmware = set_feat(getter='*IDN?')
+
+        def _post_getter(feat, driver, value):
+            """Get the identity info from the *IDN?.
+
+            """
+            infos = Parser(self.IEEE_IDN_FORMAT)(value)
+            driver._cache.update(infos)
+            return infos.get(feat.name, '')
+
+        for f in ('manufacturer', 'model', 'serial', 'firmware'):
+            setattr(i, '_post_get_' + f,
+                    customize(f, 'post_get')(_post_getter))
+
+    def is_connected(self) -> bool:
+        try:
+            self.visa_resource.query('*IDN?')
+        except Exception:
+            return False
+
+        return True
+
+
+class IEEESelfTest(VisaMessageDriver):
+    """Class implementing the self-test command.
+
+    """
+    #: Meaning of the self test result.
+    IEEE_SELF_TEST: ClassVar[Dict[int, str]] = {0: 'Normal completion'}
+
+    @Action()
+    def perform_self_test(self) -> str:
+        """Run the self test routine.
+
+        """
+        return self.IEEE_SELF_TEST.get(int(self.visa_resource.query('*TST?')),
+                                       'Unknown error')
+
+
+class IEEEReset(VisaMessageDriver):
+    """Class implementing the reset command.
+
+    """
+    IEEE_RESET_WAIT: ClassVar[int] = 1
+
+    @Action()
+    def reset(self) -> None:
+        """Initialize the instrument settings.
+
+        After running this you might need to wait a bit before sending new
+        commands to the instrument.
+
+        """
+        self.visa_resource.write('*RST')
+        self.clear_cache()
+        sleep(self.IEEE_RESET_WAIT)
+
+
+class IEEEInternalOperations(IEEEReset, IEEESelfTest, IEEEIdentity):
+    """Class implementing all the internal operations.
+
+    """
+    pass
+
+
+# =============================================================================
+# --- Synchronization ---------------------------------------------------------
+# =============================================================================
+
+class IEEEOperationComplete(VisaMessageDriver):
+    """A mixin class implementing the operation complete commands.
+
+    * `*OPC` - See IEC 60488-2:2004(E) section 10.18
+    * `*OPC?` - See IEC 60488-2:2004(E) section 10.19
+
+    """
+
+    @Action()
+    def complete_operation(self) -> None:
+        """Sets the operation complete bit high of the event status byte.
+
+        """
+        self.visa_resource.write('*OPC')
+
+    @Action()
+    def is_operation_completed(self) -> bool:
+        """Check whether or not the instrument has completed all pending
+        operations.
+
+        """
+        return bool(int(self.visa_resource.query('*OPC?')))
+
+
+class IEEEWaitToContinue(VisaMessageDriver):
+    """A mixin class implementing the wait command.
+
+    * `*WAI` - See IEC 60488-2:2004(E) section 10.39
+
+    """
+    @Action()
+    def wait_to_continue(self) -> None:
+        """Prevents the device from executing any further commands or queries
+        until the no operation flag is `True`.
+
+       Notes
+       -----
+       In devices implementing only sequential commands, the no-operation
+       flag is always True.
+
+        """
+        self.visa_resource.write('*WAI')
+
+
+class IEEESynchronisation(IEEEWaitToContinue, IEEEOperationComplete):
+    """A mixin class implementing all synchronization methods.
+
+    """
+    pass
+
+
+# =============================================================================
+# --- Power on ----------------------------------------------------------------
+# =============================================================================
+
+class IEEEPowerOn(VisaMessageDriver):
+    """A mixin class, implementing the optional power-on common commands.
+
+    The IEC 60488-2:2004(E) defines the following optional power-on common
+    commands:
+
+    * `*PSC` - See IEC 60488-2:2004(E) section 10.25
+    * `*PSC?` - See IEC 60488-2:2004(E) section 10.26
+
+    """
+    #: Represents the power-on status clear flag. If it is `False` the event
+    #: status enable, service request enable and serial poll enable registers
+    #: will retain their status when power is restored to the device and will
+    #: be cleared if it is set to `True`.
+    poweron_status_clear = Bool('*PSC?', '*PSC {}',
+                                mapping={True: '1', False: '0'})
+
+
+# =============================================================================
+# --- Resource description ----------------------------------------------------
+# =============================================================================
+
+class IEEEResourceDescription(VisaMessageDriver):
+    """A class implementing the resource description common commands.
+
+    * `*RDT` - See IEC 60488-2:2004(E) section 10.30
+    * `*RDT?` - See IEC 60488-2:2004(E) section 10.31
+
+    """
+    #: Description of the resource. The formatting is not checked.
+    resource_description = Str('*RDT?', '*RDT {}')
+
+
+# =============================================================================
+# --- Protected user data -----------------------------------------------------
+# =============================================================================
+
+class IEEEProtectedUserData(VisaMessageDriver):
+    """A class implementing the protected user data common commands.
+
+    * `*RDT` - See IEC 60488-2:2004(E) section 10.30
+    * `*RDT?` - See IEC 60488-2:2004(E) section 10.31
+
+    """
+    #: Protected user data. The validity of the passed string is not checked.
+    protected_user_data = Str('*PUD?', '*PUD {}')
+
+
+# =============================================================================
+# --- Calibration -------------------------------------------------------------
+# =============================================================================
+
+class IEEECalibration(object):
+    """A class implementing the optional calibration command.
+
+    * `*CAL?` - See IEC 60488-2:2004(E) section 10.2
+
+    """
+    CALIBRATION: ClassVar[Dict[int, str]] = {0: 'Calibration completed'}
+
+    @Action()
+    def calibrate(self) -> str:
+        """Performs a internal self-calibration.
+
+        """
+        return self.CALIBRATION.get(int(self.visa_resource.query('*CAL?')),
+                                    'Unknown error')
+
+
+# =============================================================================
+# --- Triggering --------------------------------------------------------------
+# =============================================================================
+
+class IEEETrigger(VisaMessageDriver):
+    """A class implementing the optional trigger command.
+
+    * `*TRG` - See IEC 60488-2:2004(E) section 10.37
+
+    It is mandatory for devices implementing the DT1 subset.
+
+    """
+
+    @Action()
+    def fire_trigger(self) -> None:
+        """Creates a trigger event.
+
+        """
+        self.visa_resource.write('*TRG')
+
+
+# =============================================================================
+# --- Macro trigger -----------------------------------------------------------
+# =============================================================================
+
+class IEEETriggerMacro(IEEETrigger):
+    """A class implementing the optional trigger macro commands.
+
+    * `*DDT` - See IEC 60488-2:2004(E) section 10.4
+    * `*DDT?` - See IEC 60488-2:2004(E) section 10.5
+
+    """
+    #: Sequence of commands to execute when receiving a trigger.
+    trigger_macro = Str('*DDT?', 'DDT {}')
+
+
+# =============================================================================
+# --- Option identification ---------------------------------------------------
+# =============================================================================
+
+class IEEEOptionsIdentification(VisaMessageDriver):
+    """A class implementing the option identification command.
+
+    * `*OPT?` - See IEC 60488-2:2004(E) section 10.20
+
+    """
+    #: Mapping between the value returned by the instrument (as a comma
+    #: separated list) and the names presented to the user.
+    #: When writing a driver this class variable should be updated and used
+    #: to generate the names of the feature using for example.
+    #: instr_options = set_default(names=dict.fromkeys(INSTR_OPTIONS_MAP,
+    #:                                                 bool))
+    INSTR_OPTIONS_MAP: ClassVar[Dict[str, str]] = {}
+
+    instr_options = Options('*OPT?', names={'example': bool})
+
+    @customize('instr_options', 'post_get')
+    def _convert_options(feat, driver, value):
+        """Split the returned value and identify the options.
+
+        """
+        options = dict.fromkeys(feat.names, False)
+        options.update({driver.INSTR_OPTIONS_MAP[k]: True
+                        for k in value.split(',')})
+        return options
+
+
+# =============================================================================
+# --- Stored settings ---------------------------------------------------------
+# =============================================================================
+
+class IEEEStoredSettings(VisaMessageDriver):
+    """A class implementing the stored setting commands.
+
+    * `*RCL` - See IEC 60488-2:2004(E) section 10.29
+    * `*SAV` - See IEC 60488-2:2004(E) section 10.33
+
+    """
+    @Action()
+    def recall(self, idx) -> None:
+        """Restores the current settings from a copy stored in local memory.
+
+        Parameters
+        ---------
+        idx : int
+            Specifies the memory slot.
+
+        """
+        self.visa_resource.write('*RCL {}'.format(idx))
+        self.clear_cache()
+
+    @Action()
+    def save(self, idx) -> None:
+        """Stores the current settings of a device in local memory.
+
+        Parameters
+        ----------
+        idx : int
+            Specifies the memory slot.
+
+        """
+        self.visa_resource.write('*SAV {}'.format(idx))

--- a/i3py/drivers/common/rs232.py
+++ b/i3py/drivers/common/rs232.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Base class for driver supporting the VISA RS232 communication protocol.
+
+This class ensures that the instrument is always in remote mode before
+sending any other command.
+
+"""
+from types import MethodType
+
+from i3py.backends.visa import VisaMessageDriver
+from pyvisa.resources.serial import SerialInstrument
+
+
+class VisaRS232(VisaMessageDriver):
+    """Base class for all instruments supporting the RS232 interface.
+
+    The specifity of the RS232 interface is that the device need to be switched
+    to remote mode before sending any command. This class wrapps the low-level
+    write method of the ressource when the connection is opened in RS232 mode
+    and prepend the RS232_HEADER string to the message.
+
+    """
+    #: Header to add to the message to switch the instrument in remote mode
+    #: This HAVE TO BE A BYTE STRING and should include the character
+    #: separating the two messages.
+    RS232_HEADER = b''
+
+    def initialize(self):
+        """Initialize the driver and if pertinent wrap low level so that
+        RS232_HEADER is prepended to messages.
+
+        """
+        super(VisaRS232, self).initialize()
+        if isinstance(self._resource, SerialInstrument) and self.RS232_HEADER:
+            write_raw = self._resource.write_raw.__func__
+
+            def new_write(self, message):
+                return write_raw(self, self.RS232_HEADER + message)
+            self._resource.write_raw = MethodType(new_write, self._resource)

--- a/i3py/drivers/common/scpi/__init__.py
+++ b/i3py/drivers/common/scpi/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Common utility to deal with drivers based on SCPI protocol.
+
+"""

--- a/i3py/drivers/common/scpi/error_reading.py
+++ b/i3py/drivers/common/scpi/error_reading.py
@@ -24,11 +24,11 @@ class SCPIErrorReading(VisaMessageDriver):
     def read_error(self) -> Tuple[int, str]:
         """Read the first error in the error queue.
 
-        If an unhandle error occurs, the error queue should be polled till it
+        If an unhandled error occurs, the error queue should be polled till it
         is empty.
 
         """
-        code, msg = self.query('SYST:ERR?').split(',')  # type: ignore
+        code, msg = self.visa_resource.query('SYST:ERR?').split(',')
         return int(code), msg
 
     def default_check_operation(self, feat, value, i_value, response):

--- a/i3py/drivers/common/scpi/error_reading.py
+++ b/i3py/drivers/common/scpi/error_reading.py
@@ -28,7 +28,7 @@ class SCPIErrorReading(VisaMessageDriver):
         is empty.
 
         """
-        code, msg = self.visa_resource.query('SYST:ERR?').split(',')
+        code, msg = self.visa_resource.query('SYST:ERR?').split(',', 1)
         return int(code), msg
 
     def default_check_operation(self, feat, value, i_value, response):

--- a/i3py/drivers/common/scpi/error_reading.py
+++ b/i3py/drivers/common/scpi/error_reading.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Base driver for instrument implementing SCPI error reporting commands.
+
+"""
+from typing import Tuple
+
+from i3py.core.actions import Action
+from i3py.backends.visa import VisaMessageDriver
+
+
+class SCPIErrorReading(VisaMessageDriver):
+    """Base class for all instruments implementing 'SYST:ERR?'.
+
+    """
+
+    @Action()
+    def read_error(self) -> Tuple[int, str]:
+        """Read the first error in the error queue.
+
+        If an unhandle error occurs, the error queue should be polled till it
+        is empty.
+
+        """
+        code, msg = self.query('SYST:ERR?').split(',')  # type: ignore
+        return int(code), msg
+
+    def default_check_operation(self, feat, value, i_value, response):
+        """Check if an error is present in the error queue.
+
+        """
+        code, msg = self.read_error()
+        return not bool(code), msg

--- a/i3py/drivers/common/scpi/rs232.py
+++ b/i3py/drivers/common/scpi/rs232.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Base class for SCPI instruments supporting RS232-based communication.
+
+"""
+from ..rs232 import VisaRS232
+
+
+class SCPIRS232(VisaRS232):
+    """Base class for SCPI compliant instruments supporting the RS232 protocol.
+
+    """
+
+    RS232_HEADER = b'SYST:REM:;'

--- a/i3py/drivers/hp/__init__.py
+++ b/i3py/drivers/hp/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Alias package for the Keysight package.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+from .. import keysight
+
+sys.modules[__name__] = LazyPackage({}, __name__, __doc__, locals())

--- a/i3py/drivers/itest/__init__.py
+++ b/i3py/drivers/itest/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Itest instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {'BN100': 'bn100.BN100'}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/itest/__init__.py
+++ b/i3py/drivers/itest/__init__.py
@@ -12,6 +12,7 @@
 import sys
 from i3py.core.lazy_package import LazyPackage
 
-DRIVERS = {'BN100': 'bn100.BN100'}
+DRIVERS = {'BN100': 'racks.BN100', 'BN101': 'racks.BN101',
+           'BN103': 'racks.BN103', 'BN105': 'racks.BN105'}
 
 sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/itest/modules/__init__.py
+++ b/i3py/drivers/itest/modules/__init__.py
@@ -11,6 +11,7 @@
 """
 import sys
 from i3py.core.lazy_package import LazyPackage
+from .common import make_card_detector
 
 DRIVERS = {}
 

--- a/i3py/drivers/itest/modules/__init__.py
+++ b/i3py/drivers/itest/modules/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of ITest modules.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/itest/modules/be21xx.py
+++ b/i3py/drivers/itest/modules/be21xx.py
@@ -66,9 +66,9 @@ class BE21xx(BiltModule, DCPowerSourceWithMeasure):
                     customize(f, 'post_get')(_post_getter))
 
     #: DC outputs
-    output = channel((0,))
+    outputs = channel((0,))
 
-    with output as o:
+    with outputs as o:
 
         o.enabled = set_feat(getter='OUTP?', setter='OUTP {}',
                              mapping={False: '0', True: '1'}
@@ -407,9 +407,9 @@ class BE210x(BE21xx):
     """
     __version__ = '0.1.0'
 
-    output = channel((0,))
+    outputs = channel((0,))
 
-    with output as o:
+    with outputs as o:
         #: Set the voltage settling filter. Slow 100 ms, Fast 10 ms
         o.voltage_filter = Str('VOLT:FIL?', 'VOLT:FIL {}',
                                mapping={'Slow': '0', 'Fast': '1'},
@@ -452,9 +452,9 @@ class BE214x(BE21xx):
                              '/SN{serial:s} LC{_:s} VL{firmware:s}'
                              '\\{_:d}"')
 
-    output = channel((0, 1, 2, 3))
+    outputs = channel((0, 1, 2, 3))
 
-    with output as o:
+    with outputs as o:
 
         o.OUTPUT_STATES = {0: 'enabled:constant-voltage',
                            11: 'tripped:main-failure',

--- a/i3py/drivers/itest/modules/be21xx.py
+++ b/i3py/drivers/itest/modules/be21xx.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the Itest BE21xx voltage source card.
+
+"""
+from typing import Optional, Callable
+
+from i3py.core import FloatLimitsValidator, channel, set_feat, subsystem
+from i3py.core.actions import Action
+from i3py.core.features import Float, Str, constant
+from i3py.core.job import InstrJob
+from i3py.core.unit import to_float, FLOAT_QUANTITY
+
+from ...common.ieee488 import IEEEIdentity
+from ...base.dc_sources import (DCPowerSourceWithMeasure,
+                                DCSourceTriggerSubsystem)
+from .common import BiltModule
+
+
+class BE21xx(BiltModule, DCPowerSourceWithMeasure, IEEEIdentity):
+    """Driver for the Bilt BE2100 high precision dc voltage source.
+
+    """
+    __version__ = '0.1.0'
+
+    # Identity support.
+    identity = subsystem()
+    with identity as i:
+        i.IEEE_IDN_FORMAT = ('{_:d}, "{manufacturer:s} {model:s}BB/{_:s}'
+                             '\\{serial:s} LC{_:s} VL{firmware:s}\\{_:d}')
+
+    # DC outputs
+    output = channel((0,))
+
+    with output as o:
+        o.enabled = set_feat(getter='OUT?', setter='OUT {}')
+
+        o.voltage = set_feat(getter='VOLT?', setter='VOLT {:E}',
+                             limits='voltage')
+
+        o.voltage_range = set_feat(getter='VOLT:RANG?', setter='VOLT:RANG {}',
+                                   values=(1.2, 12), extract='{},{_}',
+                                   checks=(None, 'not driver.output'),
+                                   discard={'features': ('voltage',),
+                                            'limits': ('voltage',)})
+
+        #: Specify stricter voltage limitations than the ones linked to the
+        #: range.
+        o.voltage_saturation = subsystem()
+        with o.voltage_saturation as vs:
+            #: Lowest allowed voltage.
+            vs.low = Float('VOLT:SAT:NEG?', 'VOLT:SAT:NEG {}', unit='V',
+                           limits=(-12, 0), discard={'limits': ('voltage',)})
+
+            #: Highest allowed voltage.
+            vs.high = Float('VOLT:SAT:POS?', 'VOLT:SAT:POS {}', unit='V',
+                            limits=(0, 12), discard={'limits': ('voltage',)})
+
+        o.current = set_feat(getter=constant(0.2))
+
+        o.current_range = set_feat(getter=constant(0.2))
+
+        #: Subsystem handling triggering and reaction to triggering.
+        o.trigger = subsystem(DCSourceTriggerSubsystem)
+        with o.trigger as tr:
+            #: Type of response to triggering :
+            #: - disabled : immediate update of voltage every time the voltage
+            #:   feature is updated.
+            #: - slope : update after receiving a trigger based on the slope
+            #:   value.
+            #: - stair : update after receiving a trigger using step_amplitude
+            #:   and step_width.
+            #: - step : increment by one step_amplitude till target value for
+            #:   each triggering.
+            #: - auto : update after receiving a trigger by steps but
+            #:   determining when to move to next step based on voltage
+            #:   sensing.
+            tr.mode = Str('TRIG:IN?', 'TRIG:IN {}',
+                          mapping={'disabled': '0', 'slope': '1',
+                                   'stair': '2', 'step': '4', 'auto': '5'})
+
+            #: The only valid source for the trigger is software trigger.
+            tr.source = Str(constant('software'))
+
+            #: Delay to wait after receiving a trigger event before reacting.
+            tr.delay = set_feat(getter='TRIG:IN:DEL?', setter='TRIG:IN:DEL {}',
+                                unit='ms', limits=(0, 60000, 1))
+
+            #: Voltage slope to use in slope mode.
+            tr.slope = Float('VOLT:SLOP?', 'VOLT:SLOP {}', unit='V/ms',
+                             limits=(1.2e-6, 1))
+
+            #: High of each update in stair and step mode.
+            tr.step_amplitude = Float('VOLT:ST:AMPL?', 'VOLT:ST:AMPL {}',
+                                      unit='V', limits='voltage')
+
+            #: Width of each step in stair mode.
+            tr.step_width = Float('VOLT:ST:WID?', 'VOLT:ST:WID {}', unit='ms',
+                                  limits=(100, 60000, 1))
+
+            #: Absolute threshold value of the settling tracking comparator.
+            tr.ready_amplitude = Float('TRIG:READY:AMPL?',
+                                       'TRIG:READY:AMPL {}',
+                                       unit='V', limits='voltage')
+
+            @Action()
+            def fire(self):
+                """Send a software trigger.
+
+                """
+                self.root.visa_resource.write(f'I {self.ch_id};TRIG:IN:INIT')
+
+        # XXX todo
+        @o
+        @Action()
+        def read_output_status(self) -> str:
+            """Determine the current status of the output.
+
+            """
+            answer = self.root.visa_resource.query('LIM:FAIL?')
+
+        @o
+        @Action()
+        def read_voltage_status(self) -> str:
+            """Progression of the current voltage update.
+
+            Returns
+            -------
+            progression : int
+                Progression of the voltage update. The value is between 0
+                and 1.
+
+            """
+            msg = f'I {self.parent.ch_id};VOLT:STAT?'
+            if int(self.root.visa_resource.query(msg)) == 1:
+                return 'settled'
+            else:
+                return 'changing'
+
+        @o
+        @Action(unit=((None, None, None), 'V'))
+        def measure(self, kind, **kwargs) -> FLOAT_QUANTITY:
+            """Measure the output voltage.
+
+            """
+            if kind != 'voltage':
+                raise ValueError('')
+            else:
+                return float(self.query(f'I{self.parent.ch_id};MEAS:VOLT?'))
+
+        @o
+        @Action()
+        def wait_for_settling(self,
+                              break_condition_callable:
+                                  Optional[Callable[[], bool]]=None,
+                              timeout: float=15,
+                              refresh_time: float=1) -> bool:
+            """Wait for the output to settle.
+
+             Parameters
+            ----------
+            break_condition_callable : Callable, optional
+                Callable indicating that we should stop waiting.
+
+            timeout : float, optional
+                Time to wait in seconds in addition to the expected condition
+                time before breaking.
+
+            refresh_time : float, optional
+                Time interval at which to check the break condition.
+
+            Returns
+            -------
+            result : bool
+                Boolean indicating if the wait succeeded of was interrupted.
+
+            """
+            job = InstrJob(lambda: self.read_voltage_status() == 'settled', 1)
+            return job.wait_for_completion(break_condition_callable,
+                                           timeout, refresh_time)
+
+        # =====================================================================
+        # --- Private API -----------------------------------------------------
+        # =====================================================================
+
+        @o
+        def _limits_voltage(self):
+            """Compute the voltage limits based on range and saturation.
+
+            """
+            rng = to_float(self.voltage_range)
+            low = max(-rng, float(self.voltage_saturation.low))
+            high = min(rng, float(self.voltage_saturation.high))
+
+            step = 1.2e-6 if rng == 1.2 else 1.2e-5
+
+            return FloatLimitsValidator(low, high, step, 'V')
+
+
+class BE210x(BiltModule, DCPowerSourceWithMeasure, IEEEIdentity):
+    """Driver for the Bilt BE2100 high precision dc voltage source.
+
+    """
+    __version__ = '0.1.0'
+
+    output = channel((0,))
+
+    with output as o:
+        #: Set the voltage settling filter. Slow 100 ms, Fast 10 ms
+        o.voltage_filter = Str('VOLT:FILT?', 'VOLT:FILT {}',
+                               mapping={'Slow': 0, 'Fast': 1})
+
+
+class BE2101(BiltModule, DCPowerSourceWithMeasure, IEEEIdentity):
+    """Driver for the Bilt BE2100 high precision dc voltage source.
+
+    """
+    __version__ = '0.1.0'
+
+
+class BE214x(BE21xx):
+    """Driver for the Bilt BE2100 high precision dc voltage source.
+
+    """
+    __version__ = '0.1.0'
+
+    output = channel((0, 1, 2, 3))
+
+
+class BE2141(BE214x):
+    """Driver for the Bilt BE2100 high precision dc voltage source.
+
+    """
+    __version__ = '0.1.0'

--- a/i3py/drivers/itest/modules/common.py
+++ b/i3py/drivers/itest/modules/common.py
@@ -49,6 +49,8 @@ class BiltModule(Channel):
     """Base driver for module used with the Bilt chassis.
 
     """
+    CHANNEL_ID = 'module_id'
+
     identity = subsystem(Identity)
 
     with identity as i:
@@ -58,12 +60,12 @@ class BiltModule(Channel):
         """Prepend module selection to command.
 
         """
-        cmd = 'I{ch_id};'+cmd
-        return super().default_get_feature(feat, cmd, *args, **kwargs)
+        cmd = f'I{self.id};' + cmd
+        return self.parent.default_get_feature(feat, cmd, *args, **kwargs)
 
     def default_set_feature(self, feat, cmd, *args, **kwargs):
         """Prepend module selection to command.
 
         """
-        cmd = 'I{ch_id};'+cmd
-        return super().default_set_feature(feat, cmd, *args, **kwargs)
+        cmd = f'I{self.id};' + cmd
+        return self.parent.default_set_feature(feat, cmd, *args, **kwargs)

--- a/i3py/drivers/itest/modules/common.py
+++ b/i3py/drivers/itest/modules/common.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Common tools for the Bilt module instruments.
+
+"""
+from typing import Any, Callable, List, Union
+
+from i3py.core import Channel, subsystem
+
+from ...base.identity import Identity
+
+
+def make_card_detector(model_id: Union[str, List[str]]
+                       ) -> Callable[[Any], List[str]]:
+    """Create a function listing the available card of a given model.
+
+    Parameters
+    ----------
+    model_id : str or list of str
+        Id or ids of the model. ex BE2101
+
+    """
+    if not isinstance(model_id, list):
+        model_id = [model_id]
+
+    # We strip the leading BE
+    model_id = set(m.strip('BE') for m in model_id)
+
+    def list_channel(driver):
+        """Query all the cards fitted on the rack and filter based on the model
+
+        """
+        cards = {int(i): id
+                 for i, id in [card.split(',')
+                               for card in driver.query('I:L?').split(';')]}
+
+        return [index for index in cards if cards[index] in model_id]
+
+    return list_channel
+
+
+class BiltModule(Channel):
+    """Base driver for module used with the Bilt chassis.
+
+    """
+    identity = subsystem(Identity)
+
+    with identity as i:
+        pass
+
+    def default_get_feature(self, feat, cmd, *args, **kwargs):
+        """Prepend module selection to command.
+
+        """
+        cmd = 'I{ch_id};'+cmd
+        super().default_get_feature(feat, cmd, *args, **kwargs)
+
+    def default_set_feature(self, feat, cmd, *args, **kwargs):
+        """Prepend module selection to command.
+
+        """
+        cmd = 'I{ch_id};'+cmd
+        super().default_set_feature(feat, cmd, *args, **kwargs)

--- a/i3py/drivers/itest/modules/common.py
+++ b/i3py/drivers/itest/modules/common.py
@@ -36,9 +36,9 @@ def make_card_detector(model_id: Union[str, List[str]]
         """Query all the cards fitted on the rack and filter based on the model
 
         """
+        card_list = driver.visa_resource.query('I:L?').split(';')
         cards = {int(i): id
-                 for i, id in [card.split(',')
-                               for card in driver.query('I:L?').split(';')]}
+                 for i, id in [card.split(',') for card in card_list]}
 
         return [index for index in cards if cards[index] in model_id]
 
@@ -59,11 +59,11 @@ class BiltModule(Channel):
 
         """
         cmd = 'I{ch_id};'+cmd
-        super().default_get_feature(feat, cmd, *args, **kwargs)
+        return super().default_get_feature(feat, cmd, *args, **kwargs)
 
     def default_set_feature(self, feat, cmd, *args, **kwargs):
         """Prepend module selection to command.
 
         """
         cmd = 'I{ch_id};'+cmd
-        super().default_set_feature(feat, cmd, *args, **kwargs)
+        return super().default_set_feature(feat, cmd, *args, **kwargs)

--- a/i3py/drivers/itest/racks.py
+++ b/i3py/drivers/itest/racks.py
@@ -1,0 +1,77 @@
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Driver for the Itest rack instruments
+
+"""
+from i3py.core import channel
+
+from ..common.ieee488 import IEEEReset
+from ..common.scpi.error_reading import SCPIErrorReading
+from .modules.be21xx import BE2101, BE2141
+from .modules import make_card_detector
+
+
+class BiltMainframe(IEEEReset, SCPIErrorReading):
+    """Driver for the Itest BN100 chassis.
+
+    """
+    PROTOCOLS = {'TCPIP': {'resource_class': 'SOCKET',
+                           'port': '5025'},
+                 'GPIB': {'resource_class': 'INSTR'},
+                 'ASRL': {'resource_class': 'INSTR'}
+                 }
+
+    DEFAULTS = {'COMMON': {'read_termination': '\n',
+                           'write_termination': '\n'}
+                }
+
+    IEEE_RESET_WAIT = 4
+
+    #: Support for the BE2101 card
+    be2101 = channel('_list_be2101', BE2101)
+
+    #: Support for the BE2141 card
+    be2141 = channel('_list_be2141', BE2141)
+
+    def initialize(self):
+        """Make sure the communication parameters are correctly sets.
+
+        """
+        super().initialize()
+        self.visa_resource.write('SYST:VERB 0')
+
+    _list_be2101 = make_card_detector(['BE2101'])
+    _list_be2141 = make_card_detector(['BE2141'])
+
+
+class BN100(BiltMainframe):
+    """Driver for the BN100 Bilt rack.
+
+    """
+    __version__ = '0.1.0'
+
+
+class BN101(BiltMainframe):
+    """Driver for the BN100 Bilt rack.
+
+    """
+    __version__ = '0.1.0'
+
+
+class BN103(BiltMainframe):
+    """Driver for the BN100 Bilt rack.
+
+    """
+    __version__ = '0.1.0'
+
+
+class BN105(BiltMainframe):
+    """Driver for the BN100 Bilt rack.
+
+    """
+    __version__ = '0.1.0'

--- a/i3py/drivers/itest/racks.py
+++ b/i3py/drivers/itest/racks.py
@@ -44,6 +44,8 @@ class BiltMainframe(IEEEReset, SCPIErrorReading):
         """
         super().initialize()
         self.visa_resource.write('SYST:VERB 0')
+        while self.read_error()[0]:
+            pass
 
     _list_be2101 = make_card_detector(['BE2101'])
     _list_be2141 = make_card_detector(['BE2141'])

--- a/i3py/drivers/itest/racks.py
+++ b/i3py/drivers/itest/racks.py
@@ -59,21 +59,21 @@ class BN100(BiltMainframe):
 
 
 class BN101(BiltMainframe):
-    """Driver for the BN100 Bilt rack.
+    """Driver for the BN101 Bilt rack.
 
     """
     __version__ = '0.1.0'
 
 
 class BN103(BiltMainframe):
-    """Driver for the BN100 Bilt rack.
+    """Driver for the BN103 Bilt rack.
 
     """
     __version__ = '0.1.0'
 
 
 class BN105(BiltMainframe):
-    """Driver for the BN100 Bilt rack.
+    """Driver for the BN105 Bilt rack.
 
     """
     __version__ = '0.1.0'

--- a/i3py/drivers/itest/racks.py
+++ b/i3py/drivers/itest/racks.py
@@ -44,8 +44,6 @@ class BiltMainframe(IEEEReset, SCPIErrorReading):
         """
         super().initialize()
         self.visa_resource.write('SYST:VERB 0')
-        while self.read_error()[0]:
-            pass
 
     _list_be2101 = make_card_detector(['BE2101'])
     _list_be2141 = make_card_detector(['BE2141'])

--- a/i3py/drivers/keysight/E363XA.py
+++ b/i3py/drivers/keysight/E363XA.py
@@ -1,0 +1,546 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Driver for the keysight E3633A and E3634A DC power source.
+
+"""
+from i3py.core import (FloatLimitsValidator, I3pyError, channel, customize,
+                       limit, set_feat, subsystem)
+from i3py.core.actions import Action
+from i3py.core.features import Alias, Bool, Feature, conditional
+from i3py.core.unit import to_float, to_quantity
+
+from ..base.dc_sources import (DCPowerSourceWithMeasure,
+                               DCSourceTriggerSubsystem,
+                               DCSourceProtectionSubsystem)
+from ..common.ieee488 import (IEEEInternalOperations, IEEEOperationComplete,
+                              IEEEOptionsIdentification, IEEEPowerOn,
+                              IEEEStatusReporting, IEEEStoredSettings,
+                              IEEESynchronisation, IEEETrigger)
+from ..common.scpi.error_reading import SCPIErrorReading
+from ..common.scpi.rs232 import SCPIRS232
+
+
+class KeysightE363xA(DCPowerSourceWithMeasure, IEEEInternalOperations,
+                     IEEEStatusReporting, IEEEOperationComplete,
+                     IEEEOptionsIdentification, IEEEStoredSettings,
+                     IEEETrigger, IEEESynchronisation, IEEEPowerOn,
+                     SCPIErrorReading, SCPIRS232):
+    """Driver for the Keysight E3631A DC power source.
+
+    """
+    __version__ = '0.1.0'
+
+    PROTOCOLS = {'GPIB': [{'resource_class': 'INSTR'}],
+                 'ASRL': [{'resource_class': 'INSTR'}]
+                 }
+
+    DEFAULTS = {'COMMON': {'write_termination': '\n',
+                           'read_termination': '\n'}}
+
+    output = channel((0,))
+
+    with output as o:
+
+        o.enabled = set_feat(getter='OUTP?', setter='OUTP {:d}')
+
+        o.voltage = set_feat(
+            getter=conditional(('"VOLT?" if driver.trigger.mode != "enabled"'
+                                ' else "VOLT:TRIG?"'), default=True),
+            setter=conditional(('"VOLT {}" if driver.trigger.mode != "enabled"'
+                                ' else "VOLT:TRIG {}"'), default=True),
+            limits='voltage')
+
+        o.voltage_range = set_feat(getter='VOLT:RANGE?',
+                                   setter='VOLT:RANGE {}')
+
+        o.current = set_feat(
+            getter=conditional(('"CURR?" if driver.trigger.mode != "enabled"'
+                                ' else "CURR:TRIG?"'), default=True),
+            setter=conditional(('"CURR {}" if driver.trigger.mode != "enabled"'
+                                ' else "CURR:TRIG {}"'), default=True),
+            limits='current')
+
+        o.current_range = set_feat(getter='CURR:RANGE?',
+                                   setter='CURR:RANGE {}')
+
+        @o
+        @Action(values={'quantity': ("voltage", "current")})
+        def measure(self, quantity, **kwargs):
+            """Measure the output voltage/current.
+
+            Parameters
+            ----------
+            quantity : unicode, {'voltage', 'current'}
+                Quantity to measure.
+
+            **kwargs :
+                This instrument recognize no optional parameters.
+
+            Returns
+            -------
+            value : float or pint.Quantity
+                Measured value. If units are supported the value is a Quantity
+                object.
+
+            """
+            cmd = 'MEAS:' + ('VOLT' if quantity != 'current' else 'CURR')
+            value = float(self.parent.visa_resource.query(cmd))
+            value = to_quantity(value, 'V' if quantity != 'current' else 'A')
+
+            return value
+
+        @o
+        @Action(unit=(None, (None, 'V', 'A')),
+                limits={'voltage': 'voltage', 'current': 'current'})
+        def apply(self, voltage, current):
+            """Set both the voltage and current limit.
+
+            """
+            with self.lock:
+                self.parent.visa_resource.write(f'APPLY {voltage}, {current}')
+                res, msg = self.parent.read_error()
+            if res != 0:
+                err = 'Failed to apply {}V, {}A to output {} :\n{}'
+                raise I3pyError(err.format(voltage, current, self.id, msg))
+
+        o.trigger = subsystem(DCSourceTriggerSubsystem)
+
+        with o.trigger as t:
+
+            # HINT this is a soft feature !!!
+            t.mode = set_feat(getter=True, setter=True,
+                              values=('disabled', 'enabled'))
+
+            t.source = set_feat('TRIG:SOUR?', 'TRIG:SOUR {}',
+                                mapping={'immediate': 'IMM', 'bus': 'BUS'})
+
+            t.delay = set_feat('TRIG:DEL?', 'TRIG:DEL {}',
+                               limits=(1, 3600, 1))
+
+            @o
+            @Action()
+            def arm(self):
+                """Prepare the channel to receive a trigger.
+
+                If the trigger mode is immediate the update occurs as soon as
+                the command is processed.
+
+                """
+                with self.lock:
+                    self.write('INIT')
+                    res, msg = self.root.read_error()
+                if res:
+                    err = 'Failed to arm the trigger for output {}:\n{}'
+                    raise I3pyError(err.format(self.id, msg))
+
+            # HINT mode is a "soft" feature meaning it has no reality for the
+            # the instrument. As a consequence having a default value is enough
+            # the caching does the rest for us.
+            @t
+            @customize('mode', 'get')
+            def _get_mode(feat, driver):
+                return 'disabled'
+
+            @t
+            @customize('mode', 'set')
+            def _set_mode(feat, driver, value):
+                vrsc = driver.root.visa_resource
+                vrsc.write(f'VOLT:TRIG {driver.parent.voltage}')
+                vrsc.write(f'CURR:TRIG {driver.parent.current}')
+                res, msg = self.root.read_error()
+                if res:
+                    err = ('Failed to set the triggered values for voltage '
+                           'and current {}:\n{}')
+                    raise I3pyError(err.format(self.id, msg))
+
+
+VOLTAGE_RANGES = {'P6V': 6, 'P25V': 25, 'N25V': -25}
+
+CURRENT_RANGES = {'P6V': 5, 'P25V': 1, 'N25V': 1}
+
+
+class KeysightE3631A(KeysightE363xA):
+    """Driver for the Keysight E3631A DC power source.
+
+    """
+    PROTOCOLS = {'GPIB': 'INSTR', 'ASRL': 'INSTR'}
+
+    DEFAULTS = {'COMMON': {'write_termination': '\n',
+                           'read_termination': '\n'}}
+
+    #: In this model, outputs are always enabled together.
+    outputs_enabled = Bool('OUTP?', 'OUTP {:d}',
+                           aliases={True: ['On', 'ON', 'On'],
+                                    False: ['Off', 'OFF', 'off']})
+
+    #: Whether to couple together teh output triggers, causing a trigger
+    #: received on one to update the other values.
+    coupled_triggers = Feature(getter=True, setter=True,
+                               checks=(None, ('value is False or '
+                                              'not driver.outputs_tracking'))
+                               )
+
+    #: Activate tracking between the P25V and the N25V output. In tracking
+    #: one have P25V.voltage = - N25V
+    outputs_tracking = Bool('OUTP:TRAC?',
+                            'OUTP:TRAC {}',
+                            aliases={True: ['On', 'ON', 'On'],
+                                     False: ['Off', 'OFF', 'off']},
+                            checks=(None,
+                                    ('value is False or'
+                                     'driver.coupled_triggers is None or '
+                                     '1 not in driver.coupled_triggers or '
+                                     '2 not in driver.coupled_triggers')))
+
+    output = channel((0, 1, 2),
+                     aliases={'P6V': 0, 'P25V': 1, 'N25V': 2})
+
+    with output as o:
+
+        o.enabled = Alias('.outputs_enabled')  # should this be settable ?
+
+        o.voltage_range = set_feat(getter=True)
+
+        o.current_range = set_feat(getter=True)
+
+        @o
+        @Action()
+        def measure(self, quantity, **kwargs):
+            """Measure the output voltage/current.
+
+            Parameters
+            ----------
+            quantity : unicode, {'voltage', 'current'}
+                Quantity to measure.
+
+            **kwargs :
+                This instrument recognize no optional parameters.
+
+            Returns
+            -------
+            value : float or pint.Quantity
+                Measured value. If units are supported the value is a Quantity
+                object.
+
+            """
+            with self.lock:
+                self.parent.write('INSTR:SELECT %s' % self.id)
+                super().measure(quantity, **kwargs)
+
+        @o
+        @Action()
+        def apply(self, voltage, current):
+            """Set both the voltage and current limit.
+
+            """
+            with self.lock:
+                self.parent.write('INSTR:SELECT %s' % self.id)
+                super().apply(voltage, current)
+
+        @o
+        @Action()
+        def read_output_status(self):
+            """Read the status of the output.
+
+            Returns
+            -------
+            status : unicode, {'disabled',
+                               'enabled:constant-voltage',
+                               'enabled:constant-current',
+                               'tripped:over-voltage',
+                               'tripped:over-current',
+                               'unregulated'}
+
+            """
+            if not self.enabled:
+                return 'disabled'
+            status = int(self.parent.visa_resource(
+                f'STAT:QUES:INST:ISUM{self.id + 1}?'))
+            if status & 1:
+                return 'enabled:constant-voltage'
+            if status & 2:
+                return 'enabled:constant-current'
+            return 'unregulated'
+
+        o.trigger = subsystem(DCSourceTriggerSubsystem)
+
+        with o.trigger as t:
+
+            @o
+            @Action()
+            def arm(self):
+                """Prepare the channel to receive a trigger.
+
+                If the trigger mode is immediate the update occurs as soon as
+                the command is processed.
+
+                """
+                with self.lock:
+                    self.root.visa_resource.write(f'INSTR:NSEL {self.id + 1}')
+                    super().arm()
+
+        @o
+        def default_get_feature(self, feat, cmd, *args, **kwargs):
+            """Always select the channel before getting.
+
+            """
+            cmd = f'INSTR:NSEL {self.id + 1};' + cmd
+            return super().default_get_feature(feat, cmd, *args, **kwargs)
+
+        @o
+        def default_set_feature(self, feat, cmd, *args, **kwargs):
+            """Always select the channel before getting.
+
+            """
+            cmd = f'INSTR:NSEL {self.id + 1};' + cmd
+            return super().default_set_feature(feat, cmd, *args, **kwargs)
+
+        @o
+        @customize('voltage', 'post_set', ('append',))
+        def _post_setattr_voltage(self, feat, value, i_value, state=None):
+            """Make sure that in tracking mode the voltage cache is correct.
+
+            """
+            if self.id != 0:
+                del self.parent.output[1].voltage
+                del self.parent.output[2].voltage
+
+        @o
+        @customize('voltage_range', 'get')
+        def _get_voltage_range(self, feat):
+            """Get the voltage range.
+
+            """
+            return VOLTAGE_RANGES[self.id]
+
+        @o
+        @customize('current_range', 'get')
+        def _get_current_range(self, feat):
+            """Get the current range.
+
+            """
+            return CURRENT_RANGES[self.id]
+
+        @o
+        @limit('voltage')
+        def _limits_voltage(self):
+            """Build the voltage limits matching the output.
+
+            """
+            if self.id == 'P6V':
+                return FloatLimitsValidator(0, 6.18, 1e-3, unit='V')
+            elif self.id == 'P25V':
+                return FloatLimitsValidator(0, 25.75, 1e-2, unit='V')
+            else:
+                return FloatLimitsValidator(-25.75, 0, 1e-2, unit='V')
+
+        @o
+        @limit('current')
+        def _limits_current(self):
+            """Build the current limits matching the output.
+
+            """
+            if self.id == 'P6V':
+                return FloatLimitsValidator(0, 5.15, 1e-3, unit='A')
+            elif self.id == 'P25V':
+                return FloatLimitsValidator(0, 1.03, 1e-3, unit='A')
+            else:
+                return FloatLimitsValidator(0, 1.03, 1e-3, unit='A')
+
+
+class KeysightE3633A(KeysightE363xA):
+    """Driver for the Keysight E3633A DC power source.
+
+    """
+    __version__ = '0.1.0'
+
+    output = channel((0,))
+
+    with output as o:
+
+        o.voltage_range = set_feat(values=(8, 20))
+
+        o.current_range = set_feat(values=(20, 10))
+
+        o.over_voltage_protection = subsystem(DCSourceProtectionSubsystem)
+
+        with o.over_voltage_protection as ovp:
+
+            ovp.enabled = set_feat(getter='VOLT:PROC:STAT?',
+                                   setter='VOLT:PROC:STAT {:d}')
+
+            ovp.high_level = set_feat(getter='VOLT:PROT:LEV?',
+                                      setter='VOLT:PROT:LEV {}')
+
+            ovp.low_level = set_feat(getter=True, setter=True)
+
+            @ovp
+            @Action()
+            def read_status(self) -> str:
+                """Read the status of the voltage protection
+
+                """
+                return ('tripped'
+                        if self.root.visa_resource.query('VOLT:PROT:TRIP?')
+                        else 'working')
+
+            @ovp
+            @Action()
+            def clear(self) -> None:
+                """Clear the voltage protection status.
+
+                """
+                root = self.root
+                root.visa_resource.write('VOLT:PROT:CLEAR')
+                res, msg = root.read_error()
+                if res:
+                    raise I3pyError(
+                        f'Failed to clear voltage protection: {msg}')
+
+            @ovp
+            @customize('low_level', 'get')
+            def _get_low_level(feat, driver):
+                return - driver.high_level
+
+            @ovp
+            @customize('low_level', 'get')
+            def _set_low_level(feat, driver, value):
+                driver.high_level = - value
+
+        o.over_current_protection = subsystem(DCSourceProtectionSubsystem)
+
+        with o.over_current_protection as ocp:
+
+            ovp.enabled = set_feat(getter='CURR:PROC:STAT?',
+                                   setter='CURR:PROC:STAT {:d}')
+
+            ovp.high_level = set_feat(getter='CURR:PROT:LEV?',
+                                      setter='CURR:PROT:LEV {}')
+
+            ovp.low_level = set_feat(getter=True, setter=True)
+
+            @ovp
+            @Action()
+            def read_status(self) -> str:
+                """Read the status of the voltage protection
+
+                """
+                return ('tripped'
+                        if self.root.visa_resource.query('CURR:PROT:TRIP?')
+                        else 'working')
+
+            @ovp
+            @Action()
+            def clear(self) -> None:
+                """Clear the voltage protection status.
+
+                """
+                root = self.root
+                root.visa_resource.write('CURR:PROT:CLEAR')
+                res, msg = root.read_error()
+                if res:
+                    raise I3pyError(
+                        f'Failed to clear voltage protection: {msg}')
+
+            @ovp
+            @customize('low_level', 'get')
+            def _get_low_level(feat, driver):
+                return - driver.high_level
+
+            @ovp
+            @customize('low_level', 'get')
+            def _set_low_level(feat, driver, value):
+                driver.high_level = - value
+
+        @o
+        @Action()
+        def read_output_status(self):
+            """Read the status of the output.
+
+            Returns
+            -------
+            status : unicode, {'disabled',
+                               'enabled:constant-voltage',
+                               'enabled:constant-current',
+                               'tripped:over-voltage',
+                               'tripped:over-current',
+                               'unregulated'}
+
+            """
+            status = self.parent.visa_resource.query('STAT:QUES:COND?')
+            if status == '0':
+                return 'disabled' if not self.enabled else 'unregulated'
+            elif status == '1':
+                return 'enabled:constant-voltage'
+            elif status == '2':
+                return 'enabled:constant-current'
+            else:
+                if self.over_voltage_protection.read_status() == 'tripped':
+                    return 'tripped:over-voltage'
+                else:
+                    return 'tripped:over-current'
+
+        @o
+        @limit('voltage')
+        def _limits_voltage(self):
+            """Build the voltage limits.
+
+            """
+            if to_float(self.voltage_range) == 8:
+                return FloatLimitsValidator(0, 8.24, 1e-3, unit='V')
+            else:
+                return FloatLimitsValidator(0, 20.6, 1e-2, unit='V')
+
+        @o
+        @limit('current')
+        def _limits_current(self):
+            """Build the current limits.
+
+            """
+            if to_float(self.current_range) == 20:
+                return FloatLimitsValidator(0, 20.60, 1e-3, unit='A')
+            else:
+                return FloatLimitsValidator(0, 10.3, 1e-3, unit='A')
+
+
+class KeysightE3634A(KeysightE3633A):
+    """Driver for the Keysight E3634A DC power source.
+
+    """
+    __version__ = '0.1.0'
+
+    output = channel((0,))
+
+    with output as o:
+
+        o.voltage_range = set_feat(values=(25, 50))
+
+        o.current_range = set_feat(values=(7, 4))
+
+        @o
+        @limit('voltage')
+        def _limits_voltage(self):
+            """Build the voltage limits based on the range.
+
+            """
+            if to_float(self.voltage_range) == 25:
+                return FloatLimitsValidator(0, 25.75, 1e-3, unit='V')
+            else:
+                return FloatLimitsValidator(0, 51.5, 1e-3, unit='V')
+
+        @o
+        @limit('current')
+        def _limits_current(self):
+            """Build the current limits based on the range.
+
+            """
+            if to_float(self.current_range) == 7:
+                return FloatLimitsValidator(0, 7.21, 1e-3, unit='A')
+            else:
+                return FloatLimitsValidator(0, 4.12, 1e-3, unit='A')

--- a/i3py/drivers/keysight/E363XA.py
+++ b/i3py/drivers/keysight/E363XA.py
@@ -32,6 +32,8 @@ class KeysightE363xA(DCPowerSourceWithMeasure, IEEEInternalOperations,
                      IEEEPowerOn, SCPIErrorReading, SCPIRS232):
     """Driver for the Keysight E3631A DC power source.
 
+    XXX proper format for IDN
+
     """
     __version__ = '0.1.0'
 
@@ -41,6 +43,19 @@ class KeysightE363xA(DCPowerSourceWithMeasure, IEEEInternalOperations,
 
     DEFAULTS = {'COMMON': {'write_termination': '\n',
                            'read_termination': '\n'}}
+
+    identity = subsystem()
+
+    with identity as i:
+
+        #: Format string specifying the format of the IDN query answer and
+        #: allowing to extract the following information:
+        #: - manufacturer: name of the instrument manufacturer
+        #: - model: name of the instrument model
+        #: - serial: serial number of the instrument
+        #: - firmware: firmware revision
+        #: ex {manufacturer},<{model}>,SN{serial}, Firmware revision {firmware}
+        i.IEEE_IDN_FORMAT = ''
 
     output = channel((0,))
 
@@ -178,7 +193,7 @@ class KeysightE3631A(KeysightE363xA):
                            aliases={True: ['On', 'ON', 'On'],
                                     False: ['Off', 'OFF', 'off']})
 
-    #: Whether to couple together teh output triggers, causing a trigger
+    #: Whether to couple together the output triggers, causing a trigger
     #: received on one to update the other values.
     coupled_triggers = Feature(getter=True, setter=True,
                                checks=(None, ('value is False or '

--- a/i3py/drivers/keysight/E363XA.py
+++ b/i3py/drivers/keysight/E363XA.py
@@ -18,7 +18,7 @@ from i3py.core.unit import to_float, to_quantity
 from ..base.dc_sources import (DCPowerSourceWithMeasure,
                                DCSourceTriggerSubsystem,
                                DCSourceProtectionSubsystem)
-from ..common.ieee488 import (IEEEInternalOperations, IEEEOperationComplete,
+from ..common.ieee488 import (IEEEInternalOperations,
                               IEEEOptionsIdentification, IEEEPowerOn,
                               IEEEStatusReporting, IEEEStoredSettings,
                               IEEESynchronisation, IEEETrigger)
@@ -27,10 +27,9 @@ from ..common.scpi.rs232 import SCPIRS232
 
 
 class KeysightE363xA(DCPowerSourceWithMeasure, IEEEInternalOperations,
-                     IEEEStatusReporting, IEEEOperationComplete,
-                     IEEEOptionsIdentification, IEEEStoredSettings,
-                     IEEETrigger, IEEESynchronisation, IEEEPowerOn,
-                     SCPIErrorReading, SCPIRS232):
+                     IEEEStatusReporting, IEEEOptionsIdentification,
+                     IEEEStoredSettings, IEEETrigger, IEEESynchronisation,
+                     IEEEPowerOn, SCPIErrorReading, SCPIRS232):
     """Driver for the Keysight E3631A DC power source.
 
     """

--- a/i3py/drivers/keysight/E363XA.py
+++ b/i3py/drivers/keysight/E363XA.py
@@ -8,6 +8,12 @@
 # -----------------------------------------------------------------------------
 """Driver for the Keysight E3631A, E3633A and E3634A DC power source.
 
+Notes
+-----
+
+WARNING : The drivers implemented in this module have been only very lightly
+tested.
+
 """
 from i3py.core import (FloatLimitsValidator, I3pyError, channel, customize,
                        limit, set_feat, subsystem)

--- a/i3py/drivers/keysight/__init__.py
+++ b/i3py/drivers/keysight/__init__.py
@@ -12,6 +12,7 @@
 import sys
 from i3py.core.lazy_package import LazyPackage
 
-DRIVERS = {}
+DRIVERS = {'E3631A': 'E363XA.E3631A', 'E3633A': 'E363XA.E3633A',
+           'E3634A': 'E363XA.E3634A'}
 
 sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/keysight/__init__.py
+++ b/i3py/drivers/keysight/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Keysight/Agilent/HP instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/oxford/__init__.py
+++ b/i3py/drivers/oxford/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Oxford instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/rigol/__init__.py
+++ b/i3py/drivers/rigol/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Rigol instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/rohde_schwarz/__init__.py
+++ b/i3py/drivers/rohde_schwarz/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Rohde&Schwarz instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/signal_recovery/__init__.py
+++ b/i3py/drivers/signal_recovery/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Signal Recovery instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/sp_devices/__init__.py
+++ b/i3py/drivers/sp_devices/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of SP devices instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/stanford_research/__init__.py
+++ b/i3py/drivers/stanford_research/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Stanford research instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/tektronix/__init__.py
+++ b/i3py/drivers/tektronix/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Tektronix instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/yokogawa/__init__.py
+++ b/i3py/drivers/yokogawa/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Package for the drivers of Yokogawa instruments.
+
+"""
+import sys
+from i3py.core.lazy_package import LazyPackage
+
+DRIVERS = {}
+
+sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/yokogawa/__init__.py
+++ b/i3py/drivers/yokogawa/__init__.py
@@ -12,6 +12,6 @@
 import sys
 from i3py.core.lazy_package import LazyPackage
 
-DRIVERS = {}
+DRIVERS = {'GS200': 'gs200.GS200', 'Model7651': 'model_7651.Model7651'}
 
 sys.modules[__name__] = LazyPackage(DRIVERS, __name__, __doc__, locals())

--- a/i3py/drivers/yokogawa/gs200.py
+++ b/i3py/drivers/yokogawa/gs200.py
@@ -9,15 +9,14 @@
 """Driver for the Yokogawa GS200 DC power source.
 
 """
-from i3py.core import (set_feat, subsystem, channel, limit, customize,
-                       FloatLimitsValidator)
+from i3py.core import FloatLimitsValidator, channel, customize, limit, set_feat
 from i3py.core.actions import Action
 from i3py.core.features import Str, conditional, constant
 from i3py.core.unit import to_float
 
 from ..base.dc_sources import DCPowerSource
-from ..common.ieee488 import (IEEEInternalOperations, IEEEStatusReporting,
-                              IEEEOperationComplete, IEEEOptionsIdentification,
+from ..common.ieee488 import (IEEEInternalOperations, IEEEOperationComplete,
+                              IEEEOptionsIdentification, IEEEStatusReporting,
                               IEEEStoredSettings)
 from ..common.scpi.error_reading import SCPIErrorReading
 
@@ -60,19 +59,6 @@ class GS200(DCPowerSource, IEEEInternalOperations,
 
     DEFAULTS = {'COMMON': {'read_termination': '\n',
                            'write_termination': '\n'}}
-
-    identity = subsystem()
-
-    with identity as i:
-
-        #: Format string specifying the format of the IDN query answer and
-        #: allowing to extract the following information:
-        #: - manufacturer: name of the instrument manufacturer
-        #: - model: name of the instrument model
-        #: - serial: serial number of the instrument
-        #: - firmware: firmware revision
-        #: ex {manufacturer},<{model}>,SN{serial}, Firmware revision {firmware}
-        i.IEEE_IDN_FORMAT = '{manufacturer},{model},{serial},{firmware}'
 
     output = channel((0,))
 

--- a/i3py/drivers/yokogawa/gs200.py
+++ b/i3py/drivers/yokogawa/gs200.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Driver for the Yokogawa GS200 DC power source.
+
+"""
+from i3py.core import (set_feat, channel, limit, customize,
+                       FloatLimitsValidator)
+from i3py.core.actions import Action
+from i3py.core.features import Str, conditional, constant
+from i3py.core.unit import to_float
+
+from ..base.dc_sources import DCPowerSource
+from ..common.ieee488 import (IEEEInternalOperations, IEEEStatusReporting,
+                              IEEEOperationComplete, IEEEOptionsIdentification,
+                              IEEEStoredSettings)
+from ..common.scpi.error_reading import SCPIErrorReading
+
+VOLTAGE_RESOLUTION = {10e-3: 1e-7,
+                      100e-3: 1e-6,
+                      1.0: 1e-5,
+                      10: 1e-4,
+                      30: 1e-3}
+
+CURRENT_RESOLUTION = {1e-3: 1e-8,
+                      10e-3: 1e-7,
+                      100e-3: 1e-6,
+                      200e-3: 1e-6}
+
+
+class GS200(DCPowerSource, IEEEInternalOperations,
+            IEEEStatusReporting, IEEEOperationComplete,
+            IEEEOptionsIdentification, IEEEStoredSettings,
+            SCPIErrorReading):
+    """Driver for the Yokogawa GS200 DC power source.
+
+    Notes
+    -----
+    - the measurement option is not yet supported.
+    - add support for programs
+    - add RS232 support
+
+    XXX add motivation for use of limits (basically always enabled and behave
+    just like a target value)
+
+    """
+    __version__ = '0.1.0'
+
+    PROTOCOLS = {'GPIB': [{'resource_class': 'INSTR'}],
+                 'USB': [{'resource_class': 'INSTR',
+                          'manufacturer_id': '0xB21',
+                          'model_code': '0x39'}],
+                 'TCPIP': [{'reource_class': 'INSTR'}]
+                 }
+
+    DEFAULTS = {'COMMON': {'read_termination': '\n',
+                           'write_termination': '\n'}}
+
+    output = channel((0,))
+
+    with output as o:
+        #: Preferential working mode for the source. In voltage mode, the
+        #: source tries to work as a voltage source, the current settings is
+        #: simply used to protect the sample. In current mode it is the
+        #: opposite. Changing the mode cause the output to be disabled.
+        o.mode = Str(getter=':SOUR:FUNC?',
+                     setter=':SOUR:FUNC {}',
+                     mapping={'voltage': 'VOLT', 'current': 'CURR'},
+                     discard={'feature': ('enabled',
+                                          'voltage', 'voltage_range',
+                                          'current', 'current_range'),
+                              'limits': ('voltage', 'current')})
+
+        o.voltage = set_feat(
+            getter=conditional('":SOUR:LEV?" if driver.mode == "voltage" '
+                               'else ":SOUR:PROT:VOLT?"', default=True),
+            setter=conditional('":SOUR:LEV {}" if self.mode == "voltage" '
+                               'else ":SOUR:PROT:VOLT {}"', default=True),
+            limits='voltage')
+
+        o.voltage_range = set_feat(getter=True,
+                                   setter=':SOUR:RANG {}',
+                                   checks=(None, 'driver.mode == "voltage"'),
+                                   values=(10e-3, 100e-3, 1.0, 10.0, 30.0),
+                                   discard={'features': ('ocp.enabled',
+                                                         'ocp.high_level'),
+                                            'limits': ('voltage',)})
+
+        o.voltage_limit_behavior = set_feat(getter=constant("regulate"))
+
+        o.current = set_feat(getter=True,
+                             setter=True,
+                             limits='current')
+
+        o.current_range = set_feat(getter=True,
+                                   setter=':SOUR:RANG {}',
+                                   values=(1e-3, 10e-3, 100e-3, 200e-3),
+                                   discard={'limits': 'current'})
+
+        o.voltage_limit_behavior = set_feat(getter=constant("regulate"))
+
+        @o
+        @Action()
+        def read_output_status(self):
+            """Determine the status of the output.
+
+            Returns
+            -------
+            status : str, {'disabled',
+                           'enabled:constant-voltage',
+                           'enabled:constant-voltage',
+                           'tripped:unknown', 'unregulated'}
+
+            """
+            if not self.enabled:
+                return 'disabled'
+            event = int(self.root.visa_resource.query(':STAT:EVENT?:'))
+            if event & 2**12:
+                del self.enabled
+                return 'tripped:unknown'
+            elif (event & 2**11) or (event & 2**10):
+                if self.mode == 'voltage':
+                    return 'constant current'
+                else:
+                    return 'constant voltage'
+            else:
+                if self.mode == 'voltage':
+                    return 'constant voltage'
+                else:
+                    return 'constant current'
+
+        # TODO add support for options and measuring subsystem (change
+        # inheritance)
+
+        # =====================================================================
+        # --- Private API -----------------------------------------------------
+        # =====================================================================
+
+        @o
+        @customize('current', 'get')
+        def _get_current(self, feat):
+            """Get the target/limit current.
+
+            """
+            if self.mode != 'current':
+                if to_float(self.voltage_range) in (10e-3, 100e-3):
+                    return 0.2
+                else:
+                    return self.default_get_feature(':SOUR:PROT:CURR?')
+            return self.default_get_feature(':SOUR:LEV?')
+
+        @o
+        @customize('current', 'set')
+        def _set_current(self, feat, value):
+            """Set the target/limit current.
+
+            In voltage mode this is only possible if the range is 1V or greater
+
+            """
+            if self.mode != 'current':
+                if to_float(self.voltage_range) in (10e-3, 100e-3):
+                    raise ValueError('Cannot set the current limit for ranges '
+                                     '10mV and 100mV')
+                else:
+                    return self.default_set_feature(':SOUR:PROT:CURR {}',
+                                                    value)
+            return self.default_set_feature(':SOUR:LEV {}', value)
+
+        @o
+        @limit('voltage')
+        def _limits_voltage(self):
+            """Determine the voltage limits based on the currently selected
+            range.
+
+            """
+            if self.mode == 'voltage':
+                ran = to_float(self.voltage_range)
+                res = VOLTAGE_RESOLUTION[ran]
+                if ran != 30.0:
+                    ran *= 1.2
+                else:
+                    ran = 32.0
+                return FloatLimitsValidator(-ran, ran, res, 'V')
+            else:
+                return FloatLimitsValidator(1, 30, 1, 'V')
+
+        @o
+        @limit('current')
+        def _limits_current(self):
+            """Determine the current limits based on the currently selected
+            range.
+
+            """
+            if self.mode == 'current':
+                ran = to_float(self.current_range)  # Casting handling Quantity
+                res = CURRENT_RESOLUTION[ran]
+                if ran != 200e-3:
+                    ran *= 1.2
+                else:
+                    ran = 220e-3
+                return FloatLimitsValidator(-ran, ran, res, 'A')
+            else:
+                return FloatLimitsValidator(1e-3, 0.2, 1e-3, 'A')

--- a/i3py/drivers/yokogawa/gs200.py
+++ b/i3py/drivers/yokogawa/gs200.py
@@ -38,14 +38,16 @@ class GS200(DCPowerSource, IEEEInternalOperations,
             SCPIErrorReading):
     """Driver for the Yokogawa GS200 DC power source.
 
+    Because the over-voltage (current) protection is always enabled in
+    current (voltage) mode, they basically act as limits and fully the same
+    role as target voltage (current) for a power source lacking mode selection.
+    As a consequence they are implemented in the same way.
+
     Notes
     -----
     - the measurement option is not yet supported.
     - add support for programs
     - add RS232 support
-
-    XXX add motivation for use of limits (basically always enabled and behave
-    just like a target value)
 
     """
     __version__ = '0.1.0'

--- a/i3py/drivers/yokogawa/gs200.py
+++ b/i3py/drivers/yokogawa/gs200.py
@@ -60,9 +60,9 @@ class GS200(DCPowerSource, IEEEInternalOperations,
     DEFAULTS = {'COMMON': {'read_termination': '\n',
                            'write_termination': '\n'}}
 
-    output = channel((0,))
+    outputs = channel((0,))
 
-    with output as o:
+    with outputs as o:
         #: Preferential working mode for the source. In voltage mode, the
         #: source tries to work as a voltage source, the current settings is
         #: simply used to protect the sample. In current mode it is the

--- a/i3py/drivers/yokogawa/gs200.py
+++ b/i3py/drivers/yokogawa/gs200.py
@@ -39,7 +39,7 @@ class GS200(DCPowerSource, IEEEInternalOperations,
     """Driver for the Yokogawa GS200 DC power source.
 
     Because the over-voltage (current) protection is always enabled in
-    current (voltage) mode, they basically act as limits and fully the same
+    current (voltage) mode, they basically act as limits and fullfill the same
     role as target voltage (current) for a power source lacking mode selection.
     As a consequence they are implemented in the same way.
 
@@ -90,7 +90,7 @@ class GS200(DCPowerSource, IEEEInternalOperations,
         o.voltage_range = set_feat(getter=True,
                                    setter=':SOUR:RANG {}',
                                    checks=(None, 'driver.mode == "voltage"'),
-                                   values=(10e-3, 100e-3, 1.0, 10.0, 30.0),
+                                   values=tuple(VOLTAGE_RESOLUTION.keys()),
                                    discard={'limits': ('voltage',)})
 
         o.current_limit_behavior = set_feat(getter=constant("regulate"))
@@ -101,7 +101,7 @@ class GS200(DCPowerSource, IEEEInternalOperations,
 
         o.current_range = set_feat(getter=True,
                                    setter=':SOUR:RANG {}',
-                                   values=(1e-3, 10e-3, 100e-3, 200e-3),
+                                   values=tuple(CURRENT_RESOLUTION.keys()),
                                    discard={'limits': 'current'})
 
         o.voltage_limit_behavior = set_feat(getter=constant("regulate"))

--- a/i3py/drivers/yokogawa/gs200.py
+++ b/i3py/drivers/yokogawa/gs200.py
@@ -47,6 +47,7 @@ class GS200(DCPowerSource, IEEEInternalOperations,
 
     XXX add motivation for use of limits (basically always enabled and behave
     just like a target value)
+    XXX proper format for IDN
 
     """
     __version__ = '0.1.0'
@@ -60,6 +61,19 @@ class GS200(DCPowerSource, IEEEInternalOperations,
 
     DEFAULTS = {'COMMON': {'read_termination': '\n',
                            'write_termination': '\n'}}
+
+    identity = subsystem()
+
+    with identity as i:
+
+        #: Format string specifying the format of the IDN query answer and
+        #: allowing to extract the following information:
+        #: - manufacturer: name of the instrument manufacturer
+        #: - model: name of the instrument model
+        #: - serial: serial number of the instrument
+        #: - firmware: firmware revision
+        #: ex {manufacturer},<{model}>,SN{serial}, Firmware revision {firmware}
+        i.IEEE_IDN_FORMAT = ''
 
     output = channel((0,))
 
@@ -125,14 +139,14 @@ class GS200(DCPowerSource, IEEEInternalOperations,
                 return 'tripped:unknown'
             elif (event & 2**11) or (event & 2**10):
                 if self.mode == 'voltage':
-                    return 'constant current'
+                    return 'enabled:constant-current'
                 else:
-                    return 'constant voltage'
+                    return 'enabled:constant-voltage'
             else:
                 if self.mode == 'voltage':
-                    return 'constant voltage'
+                    return 'enabled:constant-voltage'
                 else:
-                    return 'constant current'
+                    return 'enabled:constant-current'
 
         # TODO add support for options and measuring subsystem (change
         # inheritance)

--- a/i3py/drivers/yokogawa/model_7651.py
+++ b/i3py/drivers/yokogawa/model_7651.py
@@ -1,0 +1,328 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Driver for the Yokogawa 7651 DC power source.
+
+"""
+from functools import partial
+
+from i3py.core import (set_feat, set_action, channel, subsystem,
+                       limit, customize, FloatLimitsValidator)
+from i3py.core.features import conditional
+from i3py.core.unit import to_float
+from i3py.core.actions import Action, RegisterAction
+from i3py.backends.visa import VisaMessageDriver
+from stringparser import Parser
+
+from ..base.dc_sources import DCPowerSource
+from ..base.identity import Identity
+
+
+VOLTAGE_RESOLUTION = {10e-3: 1e-7,
+                      100e-3: 1e-6,
+                      1.0: 1e-5,
+                      10: 1e-4,
+                      30: 1e-3}
+
+CURRENT_RESOLUTION = {1e-3: 1e-8,
+                      10e-3: 1e-7,
+                      100e-3: 1e-6}
+
+
+class Model7651(VisaMessageDriver, DCPowerSource):
+    """Driver for the Yokogawa 7651 DC power source.
+
+    This driver can also be used on Yokogawa GS200 used in compatibility mode.
+
+    XXX add motivation for use of limits
+
+    Notes
+    -----
+    - we should check the mode on startup
+    - ideally we should not keep the VisaSession opened on GPIB
+    - add support for programs
+    - add RS232 support
+
+    """
+    __version__ = '0.1.0'
+
+    PROTOCOLS = {'GPIB': [{'resource_class': 'INSTR'}]}
+
+    DEFAULTS = {'COMMON': {'read_termination': '\r\n'},
+                'ASRL': {'write_termination': '\r\n'}}
+
+    def initialize(self):
+        """Set the data termination.
+
+        """
+        super().initialize()
+        self.visa_resource.write('DL0')  # Choose the termination character
+        self.visa_resource.write('MS31')  # Unmask the status byte by default.
+
+    @RegisterAction(('Program setting',  # Program is currently edited
+                     'Program execution',  # Program under execution
+                     'Error',  # Previous command error
+                     'Output unustable',
+                     'Output on',
+                     'Calibration mode',
+                     'IC memory card',
+                     'CAL switch'))
+    def read_status_code(self):  # Should this live in a subsystem ?
+        """Read the status code.
+
+        """
+        return int(self.visa_resource.query('OC'))
+
+    read_status_byte = set_action(names=('End of output change',
+                                         'SRQ key on',
+                                         'Syntax error',
+                                         'Limit error',
+                                         'Program end',
+                                         'Error',
+                                         'Request',
+                                         7))
+
+    def is_connected(self):
+        """Check whether or not the connection is opened.
+
+        """
+        try:
+            self.visa.resource.query('OC')
+        except Exception:
+            return False
+
+        return True
+
+    identity = subsystem(Identity)
+
+    with identity as i:
+
+        i.model = set_feat(getter=True)
+
+        i.firmware = set_feat(getter=True)
+
+        def _get_from_os(index, self):
+            """Read the requested info from OS command.
+
+            """
+            visa_rsc = self.parent.visa_resource
+            mes = visa_rsc.query('OS')
+            visa_rsc.read()
+            visa_rsc.read()
+            visa_rsc.read()
+            visa_rsc.read()
+            return mes.split(',')[index]
+
+        i._get_model = customize('model', 'get')(partial(0, i._get_from_os))
+
+        i._get_firmware = customize('model', 'get')(partial(1, i._get_from_os))
+
+    output = channel((1,))
+
+    with output as o:
+        o.function = set_feat(getter='OD',
+                              setter='F{}E',
+                              mapping=({'Voltage': '1', 'Current': '5'},
+                                       {'V': 'Voltage', 'A': 'Current'}),
+                              extract='{_}DC{}{_:+E}')
+
+        o.enabled = set_feat(getter=True,
+                             setter='O{}E',
+                             mapping={True: 1, False: 0})
+
+        o.voltage = set_feat(
+            getter=True,
+            setter=conditional('"S{+E}E" if driver.mode == "voltage" '
+                               'else "LV{}E"', default=True),
+            limits='voltage')
+
+        o.voltage_range = set_feat(getter=True,
+                                   setter='R{}E',
+                                   extract='F1R{}S{_}',
+                                   mapping={10e-3: 2, 100e-3: 3, 1.0: 4,
+                                            10.0: 5, 30.0: 6},
+                                   discard={'features': ('current'),
+                                            'limits': ('voltage',)})
+
+        o.current = set_feat(getter=True,
+                             setter=True,
+                             limits='current')
+
+        o.current_range = set_feat(getter=True,
+                                   setter='R{}E',
+                                   extract='F5R{}S{_}',
+                                   mapping={1e-3: 4, 10e-3: 5, 100e-3: 6},
+                                   discard={'limits': ('current',)})
+
+        @o
+        @Action()
+        def read_output_status(self):
+            """Determine the status of the output.
+
+            Returns
+            -------
+            status : unicode, {'disabled',
+                               'enabled:constant-voltage',
+                               'enabled:constant-voltage',
+                               'tripped:unknown', 'unregulated'}
+
+            """
+            if not self.enabled:
+                return 'disabled'
+            if 'Output on' not in self.parent.read_status_code():
+                return 'tripped:unknown'
+            if self.parent.query('OD')[0] == 'E':
+                if self.mode == 'voltage':
+                    return 'enabled:constant-current'
+                else:
+                    return 'enabled:constant-voltage'
+            if self.mode == 'voltage':
+                return 'enabled:constant-voltage'
+            else:
+                return 'enabled:constant-current'
+
+        # =====================================================================
+        # --- Private API -----------------------------------------------------
+        # =====================================================================
+
+        @o
+        def default_check_operation(self, feat, value, i_value, state=None):
+            """Check that the operation did not result in any error.
+
+            """
+            stb = self.parent.visa_resource.read_status_byte()
+            if stb['Syntax error']:
+                msg = 'Syntax error' if stb['Limit error'] else 'Overload'
+                return False, msg
+
+            return True, None
+
+        @o
+        @limit('voltage')
+        def _limits_voltage(self):
+            """Determine the voltage limits based on the currently selected
+            range.
+
+            """
+            if self.mode == 'voltage':
+                ran = to_float(self.voltage_range)
+                res = VOLTAGE_RESOLUTION[ran]
+                if ran != 30.0:
+                    ran *= 1.2
+                else:
+                    ran = 32.0
+                return FloatLimitsValidator(-ran, ran, res, 'V')
+            else:
+                return FloatLimitsValidator(1, 30, 1, 'V')
+
+        @o
+        @limit('current')
+        def _limits_current(self):
+            """Determine the current limits based on the currently selected
+            range.
+
+            """
+            if self.mode == 'voltage':
+                ran = float(self.current_range)  # Casting handling Quantity
+                res = CURRENT_RESOLUTION[ran]
+                if ran != 200e-3:
+                    ran *= 1.2
+                else:
+                    ran = 220e-3
+                return FloatLimitsValidator(-ran, ran, res, 'A')
+            else:
+                return FloatLimitsValidator(5e-3, 120e-3, 1e-3, 'A')
+
+        @o
+        @customize('enabled', 'get')
+        def _get_enabled(self):
+            """Read the output current status byte and extract the output state
+
+            """
+            return 'Output' in self.parent.read_status_code()
+
+        o._OD_PARSER = Parser('{_}DC{_}{:E+}')
+
+        o._VOLT_LIM_PARSER = Parser('LV{}LA{_}')
+
+        o._CURR_LIM_PARSER = Parser('LV{_}LA{}')
+
+        @o
+        @customize('voltage', 'get')
+        def _get_voltage(self, feat):
+            """Get the voltage in voltage mode and return the maximum voltage
+            in current mode.
+
+            """
+            if self.mode != 'voltage':
+                return self._VOLT_LIM_PARSER(self._get_limiter_value())
+            return self._OD_PARSER(self.default_get_feature('OD'))
+
+        @o
+        @customize('current', 'get')
+        def _get_current(self, feat):
+            """Get the current in current mode and return the maximum current
+            in voltage mode.
+
+            """
+            if self.mode != 'voltage':
+                if to_float(self.voltage_range) in (10e-3, 100e-3):
+                    return 0.12
+                return self._CURR_LIM_PARSER(self._get_limiter_value())*1e3
+            return self._OD_PARSER(self.default_get_feature('OD'))
+
+        @o
+        @customize('current', 'set')
+        def _set_current(self, feat, value):
+            """Set the target/limit current.
+
+            In voltage mode this is only possible if the range is 1V or greater
+
+            """
+            if self.mode != 'current':
+                if to_float(self.voltage_range) in (10e-3, 100e-3):
+                    raise ValueError('Cannot set the current limit for ranges '
+                                     '10mV and 100mV')
+                else:
+                    return self.default_set_feature('LA{}E', value)
+            return self.default_set_feature('S{+E}E', value)
+
+        @o
+        def _get_limiter_value(self):
+            """Helper function reading the limiter value.
+
+            Used to read the voltage/current target.
+
+            """
+            visa_rsc = self.parent.visa_resource
+            visa_rsc.write('OS')
+            visa_rsc.read()  # Model and software version
+            visa_rsc.read()  # Function, range, output data
+            visa_rsc.read()  # Program parameters
+            return visa_rsc.read()  # Limits
+
+        def _get_range(kind, self):
+            """Read the range.
+
+            """
+            visa_rsc = self.parent.visa_resource
+            if self.mode == kind:
+                visa_rsc.write('OS')
+                visa_rsc.read()  # Model and software version
+                msg = visa_rsc.read()  # Function, range, output data
+                visa_rsc.read()  # Program parameters
+                visa_rsc.read()  # Limits
+                return msg
+            else:
+                return 'F{}R6S1E+0'.format(1 if kind == 'voltage' else 5)
+
+        o._get_voltage_range = customize('voltage_range',
+                                         'get')(partial(_get_range, 'voltage'))
+
+        o._get_current_range = customize('current_range',
+                                         'get')(partial(_get_range, 'current'))

--- a/i3py/drivers/yokogawa/model_7651.py
+++ b/i3py/drivers/yokogawa/model_7651.py
@@ -37,7 +37,10 @@ class Model7651(VisaMessageDriver, DCPowerSource):
 
     This driver can also be used on Yokogawa GS200 used in compatibility mode.
 
-    XXX add motivation for use of limits
+    Because the over-voltage (current) protection is always enabled in
+    current (voltage) mode, they basically act as limits and fully the same
+    role as target voltage (current) for a power source lacking mode selection.
+    As a consequence they are implemented in the same way.
 
     Notes
     -----

--- a/i3py/drivers/yokogawa/model_7651.py
+++ b/i3py/drivers/yokogawa/model_7651.py
@@ -143,9 +143,9 @@ class Model7651(VisaMessageDriver, DCPowerSource):
         def _get_firmware(feat, driver):
             return driver._get_from_os(1)
 
-    output = channel((0,))
+    outputs = channel((0,))
 
-    with output as o:
+    with outputs as o:
         o.mode = Str('OD', 'F{}E',
                      mapping=({'voltage': '1', 'current': '5'},
                               {'V': 'voltage', 'A': 'current'}),

--- a/tests/drivers/itest/t_be2101.py
+++ b/tests/drivers/itest/t_be2101.py
@@ -26,8 +26,11 @@ with BN100(VISA_RESOURCE_NAME) as rack:
 
     module = rack.be2101[MODULE_INDEX]
     print(module.identity.manufacturer)
+    print(module.identity.model)
+    print(module.identity.serial)
+    print(module.identity.firmware)
 
-    output = module.output[0]
+    output = module.output[1]
     for f_name in output.__feats__:
         print(f_name, getattr(output, f_name))
 

--- a/tests/drivers/itest/t_be2101.py
+++ b/tests/drivers/itest/t_be2101.py
@@ -18,11 +18,12 @@ VISA_RESOURCE_NAME = 'TCPIP::192.168.0.10::5025::SOCKET'
 # Index of the slot in which the BE2101 can be found (starting from 1)
 MODULE_INDEX = 1
 
+from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
 from i3py.drivers.itest import BN100
 
 with BN100(VISA_RESOURCE_NAME) as rack:
 
-        # Test reading all features
+    # Test reading all features
     print('Available modules', rack.be2101.available)
 
     module = rack.be2101[MODULE_INDEX]
@@ -32,20 +33,63 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     print('Firmware', module.identity.firmware)
 
     print('Testing output')
-    output = module.output[1]
+    output = module.output[0]
     for f_name in output.__feats__:
         print('    ', f_name, getattr(output, f_name))
+        delattr(output, f_name)
 
     for sub_name in output.__subsystems__:
         print('  Testing ', sub_name)
         sub = getattr(output, sub_name)
         for f_name in sub.__feats__:
             print('      ', f_name, getattr(sub, f_name))
+            delattr(sub, f_name)
 
     # Test action reading basic status
     print('Output status', output.read_output_status())
     output.clear_output_status()
-    print('Voltage status', output.read_voltage_status())
     print('Measured output voltage', output.measure('voltage'))
 
     # Test settings and general behavior
+    print('Setting outputs')
+    output.enabled = False
+    output.trigger.mode = 'disabled'
+    output.voltage = 0
+    output.wait_for_settling()
+    output.voltage_saturation.low_enabled = False
+    output.voltage_saturation.high_enabled = False
+    print('Known limits', output.declared_limits)
+    output.voltage_range = 1.2
+    output.voltage_filter = ('Slow' if output.voltage_filter == 'Fast' else
+                             'Fast')
+    output.remote_sensing = True
+    del output.remote_sensing
+    print('Remote sensing is ', output.remote_sensing)
+    output.remote_sensing = False
+    output.enabled = True
+
+    output.voltage = 1.0
+    try:
+        output.read_voltage_status()
+    except I3pyFailedCall:
+        print('Cannot read voltage status in non-triggered mode')
+    output.wait_for_settling()
+
+    # TODO test the other trigger modes and other sync methods
+    output.trigger.mode = 'slope'
+    output.trigger.slope = 0.01
+    output.voltage = 0.5
+    output.trigger.fire()
+    output.wait_for_settling()
+    print(f'Measured output is {output.measure("voltage")}, '
+          f'target is {output.voltage}')
+
+    output.voltage_saturation.low_enabled = True
+    output.voltage_saturation.high_enabled = True
+    output.voltage_saturation.low = -0.5
+    output.voltage_saturation.high = 0.4
+    print('New voltage', output.voltage)
+    try:
+        output.voltage = -0.6
+    except I3pyFailedSet:
+        print('New restriction on the gate voltage')

--- a/tests/drivers/itest/t_be2101.py
+++ b/tests/drivers/itest/t_be2101.py
@@ -33,7 +33,7 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     print('Firmware', module.identity.firmware)
 
     print('Testing output')
-    output = module.output[0]
+    output = module.outputs[0]
     for f_name in output.__feats__:
         print('    ', f_name, getattr(output, f_name))
         delattr(output, f_name)

--- a/tests/drivers/itest/t_be2141.py
+++ b/tests/drivers/itest/t_be2141.py
@@ -22,10 +22,10 @@ from i3py.drivers.itest import BN100
 
 with BN100(VISA_RESOURCE_NAME) as rack:
 
-        # Test reading all features
-    print('Available modules', rack.be2101.available)
+    # Test reading all features
+    print('Available modules', rack.be2141.available)
 
-    module = rack.be2101[MODULE_INDEX]
+    module = rack.be2141[MODULE_INDEX]
     print('Manufacturer', module.identity.manufacturer)
     print('Model', module.identity.model)
     print('Serial number', module.identity.serial)

--- a/tests/drivers/itest/t_be2141.py
+++ b/tests/drivers/itest/t_be2141.py
@@ -6,7 +6,7 @@
 #
 # The full license is in the file LICENCE, distributed with this software.
 # -----------------------------------------------------------------------------
-"""This file is meant to check the working of the driver for the BE2101.
+"""This file is meant to check the working of the driver for the BE2141.
 
 The rack is expected to have a BE2101 in one slot, whose output can be safely
 switched on and off and whose output value can vary (and has a large impedance)
@@ -33,7 +33,7 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     print('Firmware', module.identity.firmware)
 
     print('Testing output')
-    output = module.output[1]
+    output = module.output[0]
     for f_name in output.__feats__:
         print('    ', f_name, getattr(output, f_name))
 

--- a/tests/drivers/itest/t_be2141.py
+++ b/tests/drivers/itest/t_be2141.py
@@ -18,6 +18,7 @@ VISA_RESOURCE_NAME = 'TCPIP::192.168.0.10::5025::SOCKET'
 # Index of the slot in which the BE2101 can be found (starting from 1)
 MODULE_INDEX = 1
 
+from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
 from i3py.drivers.itest import BN100
 
 with BN100(VISA_RESOURCE_NAME) as rack:
@@ -45,7 +46,40 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     # Test action reading basic status
     print('Output status', output.read_output_status())
     output.clear_output_status()
-    print('Voltage status', output.read_voltage_status())
     print('Measured output voltage', output.measure('voltage'))
 
     # Test settings and general behavior
+    print('Setting ouputs')
+    output.voltage_saturation.low_enabled = False
+    output.voltage_saturation.high_enabled = False
+    print('Known limits', output.declared_limits)
+    output.trigger.mode = 'disabled'
+    output.voltage_range = 1.2
+    output.enabled = True
+    output.voltage = 1.0
+    try:
+        output.read_voltage_status()
+    except I3pyFailedCall:
+        print('Cannot read voltage status in non-triggered mode')
+    try:
+        output.wait_for_settling()
+    except I3pyFailedCall:
+        print('Cannot wait for settling in non-triggered mode')
+
+    # XXX test the other trigger modes
+    output.trigger.mode = 'slope'
+    output.trigger.slope = 0.01
+    output.voltage = 0.5
+    output.trigger.fire()
+    output.wait_for_settling()
+    print(output.measure('voltage'))
+
+    output.voltage_saturation.low_enabled = True
+    output.voltage_saturation.high_enabled = True
+    output.voltage_saturation.low = -0.5
+    output.voltage_saturation.high = 0.4
+    print('New voltage', output.voltage)
+    try:
+        output.voltage = -0.6
+    except I3pyFailedSet:
+        print('New restriction on the gate voltage')

--- a/tests/drivers/itest/t_be2141.py
+++ b/tests/drivers/itest/t_be2141.py
@@ -36,12 +36,14 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     output = module.output[0]
     for f_name in output.__feats__:
         print('    ', f_name, getattr(output, f_name))
+        delattr(output, f_name)
 
     for sub_name in output.__subsystems__:
         print('  Testing ', sub_name)
         sub = getattr(output, sub_name)
         for f_name in sub.__feats__:
             print('      ', f_name, getattr(sub, f_name))
+            delattr(sub, f_name)
 
     # Test action reading basic status
     print('Output status', output.read_output_status())
@@ -49,7 +51,7 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     print('Measured output voltage', output.measure('voltage'))
 
     # Test settings and general behavior
-    print('Setting ouputs')
+    print('Setting outputs')
     output.voltage_saturation.low_enabled = False
     output.voltage_saturation.high_enabled = False
     print('Known limits', output.declared_limits)
@@ -61,18 +63,16 @@ with BN100(VISA_RESOURCE_NAME) as rack:
         output.read_voltage_status()
     except I3pyFailedCall:
         print('Cannot read voltage status in non-triggered mode')
-    try:
-        output.wait_for_settling()
-    except I3pyFailedCall:
-        print('Cannot wait for settling in non-triggered mode')
+    output.wait_for_settling()
 
-    # XXX test the other trigger modes
+    # TODO test the other trigger modes and other sync methods
     output.trigger.mode = 'slope'
     output.trigger.slope = 0.01
     output.voltage = 0.5
     output.trigger.fire()
     output.wait_for_settling()
-    print(output.measure('voltage'))
+    print(f'Measured output is {output.measure("voltage")}, '
+          f'target is {output.voltage}')
 
     output.voltage_saturation.low_enabled = True
     output.voltage_saturation.high_enabled = True

--- a/tests/drivers/itest/t_be2141.py
+++ b/tests/drivers/itest/t_be2141.py
@@ -33,7 +33,7 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     print('Firmware', module.identity.firmware)
 
     print('Testing output')
-    output = module.output[0]
+    output = module.outputs[0]
     for f_name in output.__feats__:
         print('    ', f_name, getattr(output, f_name))
         delattr(output, f_name)

--- a/tests/drivers/itest/test_be2101.py
+++ b/tests/drivers/itest/test_be2101.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""This file is meant to check the working of the driver for the BE2101.
+
+The rack is expected to have a BE2101 in one slot, whose output can be safely
+switched on and off and whose output value can vary (and has a large impedance)
+
+"""
+# Visa connection info
+VISA_RESOURCE_NAME = 'TCPIP::192.168.0.10::5025::SOCKET'
+
+# Index of the slot in which the BE2101 can be found (starting from 1)
+MODULE_INDEX = 1
+
+from i3py.drivers.itest import BN100
+
+with BN100(VISA_RESOURCE_NAME) as rack:
+
+    print(rack.be2101.available)
+
+    module = rack.be2101[MODULE_INDEX]
+    print(module.manufacturer)
+
+    output = module.output[0]
+    for f_name in output.__feats__:
+        print(getattr(output, f_name))
+
+    for sub in output.__subsystems__:
+        for f_name in sub.__feats__:
+            print(getattr(output, f_name))

--- a/tests/drivers/itest/test_be2101.py
+++ b/tests/drivers/itest/test_be2101.py
@@ -25,12 +25,14 @@ with BN100(VISA_RESOURCE_NAME) as rack:
     print(rack.be2101.available)
 
     module = rack.be2101[MODULE_INDEX]
-    print(module.manufacturer)
+    print(module.identity.manufacturer)
 
     output = module.output[0]
     for f_name in output.__feats__:
-        print(getattr(output, f_name))
+        print(f_name, getattr(output, f_name))
 
-    for sub in output.__subsystems__:
+    for sub_name in output.__subsystems__:
+        print('testing ', sub_name)
+        sub = getattr(output, sub_name)
         for f_name in sub.__feats__:
-            print(getattr(output, f_name))
+            print(getattr(sub, f_name))

--- a/tests/drivers/keysight/t_E3631A.py
+++ b/tests/drivers/keysight/t_E3631A.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""This file is meant to check the working of the driver for the E3631A.
+
+The instrument is expected to be in a situation where output can be safely
+switched on and off and whose output value can vary (and has a large impedance)
+
+"""
+# Visa connection info
+VISA_RESOURCE_NAME = 'GPIB::10::INSTR'
+
+from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
+from i3py.drivers.keysight import E3631A
+
+with E3631A(VISA_RESOURCE_NAME) as driver:
+
+    # Test reading all features
+    print('Manufacturer', driver.identity.manufacturer)
+    print('Model', driver.identity.model)
+    print('Serial number', driver.identity.serial)
+    print('Firmware', driver.identity.firmware)
+
+    print('Testing output')
+    for output in driver.output:
+        for f_name in output.__feats__:
+            print('    ', f_name, getattr(output, f_name))
+
+        for sub_name in output.__subsystems__:
+            print('  Testing ', sub_name)
+            sub = getattr(output, sub_name)
+            for f_name in sub.__feats__:
+                print('      ', f_name, getattr(sub, f_name))
+
+        # Test action reading basic status
+        print('Output status', output.read_output_status())
+        output.clear_output_status()
+        print('Measured output voltage', output.measure('voltage'))
+        print('Measured output current', output.measure('current'))
+
+    # XXX add more comprehensive tests

--- a/tests/drivers/keysight/t_E3631A.py
+++ b/tests/drivers/keysight/t_E3631A.py
@@ -13,7 +13,7 @@ switched on and off and whose output value can vary (and has a large impedance)
 
 """
 # Visa connection info
-VISA_RESOURCE_NAME = 'GPIB::10::INSTR'
+VISA_RESOURCE_NAME = 'GPIB::2::INSTR'
 
 from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
 from i3py.drivers.keysight import E3631A
@@ -26,8 +26,12 @@ with E3631A(VISA_RESOURCE_NAME) as driver:
     print('Serial number', driver.identity.serial)
     print('Firmware', driver.identity.firmware)
 
+    print('Outputs enabled', driver.outputs_enabled)
+    print('Coupled triggers', driver.coupled_triggers)
+    print('Outputs tracking', driver.outputs_tracking)
+
     print('Testing output')
-    for output in driver.output:
+    for output in driver.outputs:
         for f_name in output.__feats__:
             print('    ', f_name, getattr(output, f_name))
 
@@ -39,8 +43,7 @@ with E3631A(VISA_RESOURCE_NAME) as driver:
 
         # Test action reading basic status
         print('Output status', output.read_output_status())
-        output.clear_output_status()
         print('Measured output voltage', output.measure('voltage'))
         print('Measured output current', output.measure('current'))
 
-    # XXX add more comprehensive tests
+    # TODO add more comprehensive tests

--- a/tests/drivers/yokogawa/t_gs200.py
+++ b/tests/drivers/yokogawa/t_gs200.py
@@ -27,7 +27,7 @@ with GS200(VISA_RESOURCE_NAME) as driver:
     print('Firmware', driver.identity.firmware)
 
     print('Testing output')
-    output = driver.output[0]
+    output = driver.outputs[0]
     for f_name in output.__feats__:
         print('    ', f_name, getattr(output, f_name))
 

--- a/tests/drivers/yokogawa/t_gs200.py
+++ b/tests/drivers/yokogawa/t_gs200.py
@@ -13,7 +13,7 @@ switched on and off and whose output value can vary (and has a large impedance)
 
 """
 # Visa connection info
-VISA_RESOURCE_NAME = 'USB::::INSTR'
+VISA_RESOURCE_NAME = 'USB::0x0B21::0x0039::91N326145::INSTR'
 
 from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
 from i3py.drivers.yokogawa import GS200
@@ -39,14 +39,12 @@ with GS200(VISA_RESOURCE_NAME) as driver:
 
     # Test action reading basic status
     print('Output status', output.read_output_status())
-    output.clear_output_status()
-    print('Measured output voltage', output.measure('voltage'))
-    print('Measured output current', output.measure('current'))
 
     # Test voltage mode
     print('Voltage mode')
     output.enabled = False
     output.mode = 'voltage'
+    print(output.check_cache())
     print('Known limits', output.declared_limits)
     output.voltage_range = 1
     output.enabled = True
@@ -57,9 +55,14 @@ with GS200(VISA_RESOURCE_NAME) as driver:
     # Test current mode
     print('Current mode')
     output.mode = 'current'
+    print(output.check_cache())
+    # del output.enabled
     assert not output.enabled
     output.enabled = True
     output.current_range = 0.2
     output.voltage = 10
     output.current = 0.1
     assert output.read_output_status() == 'enabled:constant-voltage'
+
+    driver.visa_resource.write('x_x')
+    driver.read_error()

--- a/tests/drivers/yokogawa/t_gs200.py
+++ b/tests/drivers/yokogawa/t_gs200.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""This file is meant to check the working of the driver for the GS200.
+
+The instrument is expected to be in a situation where output can be safely
+switched on and off and whose output value can vary (and has a large impedance)
+
+"""
+# Visa connection info
+VISA_RESOURCE_NAME = 'USB::::INSTR'
+
+from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
+from i3py.drivers.yokogawa import GS200
+
+with GS200(VISA_RESOURCE_NAME) as driver:
+
+    # Test reading all features
+    print('Manufacturer', driver.identity.manufacturer)
+    print('Model', driver.identity.model)
+    print('Serial number', driver.identity.serial)
+    print('Firmware', driver.identity.firmware)
+
+    print('Testing output')
+    output = driver.output[0]
+    for f_name in output.__feats__:
+        print('    ', f_name, getattr(output, f_name))
+
+    for sub_name in output.__subsystems__:
+        print('  Testing ', sub_name)
+        sub = getattr(output, sub_name)
+        for f_name in sub.__feats__:
+            print('      ', f_name, getattr(sub, f_name))
+
+    # Test action reading basic status
+    print('Output status', output.read_output_status())
+    output.clear_output_status()
+    print('Measured output voltage', output.measure('voltage'))
+    print('Measured output current', output.measure('current'))
+
+    # Test voltage mode
+    print('Voltage mode')
+    output.enabled = False
+    output.mode = 'voltage'
+    print('Known limits', output.declared_limits)
+    output.voltage_range = 1
+    output.enabled = True
+    output.voltage = 1.0
+    output.current = 0.2
+    assert output.read_output_status() == 'enabled:constant-voltage'
+
+    # Test current mode
+    print('Current mode')
+    output.mode = 'current'
+    assert not output.enabled
+    output.enabled = True
+    output.current_range = 0.2
+    output.voltage = 10
+    output.current = 0.1
+    assert output.read_output_status() == 'enabled:constant-voltage'

--- a/tests/drivers/yokogawa/t_model7651.py
+++ b/tests/drivers/yokogawa/t_model7651.py
@@ -29,7 +29,7 @@ with Model7651(VISA_RESOURCE_NAME) as driver:
     print('Firmware', driver.identity.firmware)
 
     print('Testing output')
-    output = driver.output[0]
+    output = driver.outputs[0]
     for f_name in output.__feats__:
         print('    ', f_name, getattr(output, f_name))
 

--- a/tests/drivers/yokogawa/t_model7651.py
+++ b/tests/drivers/yokogawa/t_model7651.py
@@ -13,14 +13,16 @@ switched on and off and whose output value can vary (and has a large impedance)
 
 """
 # Visa connection info
-VISA_RESOURCE_NAME = 'GPIB::10::INSTR'
+VISA_RESOURCE_NAME = 'GPIB0::5::INSTR'
 
+from time import sleep
 from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
 from i3py.drivers.yokogawa import Model7651
 
 with Model7651(VISA_RESOURCE_NAME) as driver:
 
     # Test reading all features
+    assert driver.is_connected()
     print('Manufacturer', driver.identity.manufacturer)
     print('Model', driver.identity.model)
     print('Serial number', driver.identity.serial)
@@ -39,27 +41,29 @@ with Model7651(VISA_RESOURCE_NAME) as driver:
 
     # Test action reading basic status
     print('Output status', output.read_output_status())
-    output.clear_output_status()
-    print('Measured output voltage', output.measure('voltage'))
-    print('Measured output current', output.measure('current'))
 
     # Test voltage mode
     print('Voltage mode')
     output.enabled = False
     output.mode = 'voltage'
+    print(output.check_cache())
     print('Known limits', output.declared_limits)
     output.voltage_range = 1
     output.enabled = True
     output.voltage = 1.0
-    output.current = 0.2
+    output.current = 0.1
+    sleep(1)
     assert output.read_output_status() == 'enabled:constant-voltage'
 
     # Test current mode
     print('Current mode')
     output.mode = 'current'
+    print(output.check_cache())
     assert not output.enabled
+    output.current = 0
     output.enabled = True
-    output.current_range = 0.2
+    output.current_range = 0.1
     output.voltage = 10
-    output.current = 0.1
+    output.current = 0.05
+    sleep(1)
     assert output.read_output_status() == 'enabled:constant-voltage'

--- a/tests/drivers/yokogawa/t_model7651.py
+++ b/tests/drivers/yokogawa/t_model7651.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2018 by I3py Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""This file is meant to check the working of the driver for the 7651.
+
+The instrument is expected to be in a situation where output can be safely
+switched on and off and whose output value can vary (and has a large impedance)
+
+"""
+# Visa connection info
+VISA_RESOURCE_NAME = 'GPIB::10::INSTR'
+
+from i3py.core.errors import I3pyFailedCall, I3pyFailedSet
+from i3py.drivers.yokogawa import Model7651
+
+with Model7651(VISA_RESOURCE_NAME) as driver:
+
+    # Test reading all features
+    print('Manufacturer', driver.identity.manufacturer)
+    print('Model', driver.identity.model)
+    print('Serial number', driver.identity.serial)
+    print('Firmware', driver.identity.firmware)
+
+    print('Testing output')
+    output = driver.output[0]
+    for f_name in output.__feats__:
+        print('    ', f_name, getattr(output, f_name))
+
+    for sub_name in output.__subsystems__:
+        print('  Testing ', sub_name)
+        sub = getattr(output, sub_name)
+        for f_name in sub.__feats__:
+            print('      ', f_name, getattr(sub, f_name))
+
+    # Test action reading basic status
+    print('Output status', output.read_output_status())
+    output.clear_output_status()
+    print('Measured output voltage', output.measure('voltage'))
+    print('Measured output current', output.measure('current'))
+
+    # Test voltage mode
+    print('Voltage mode')
+    output.enabled = False
+    output.mode = 'voltage'
+    print('Known limits', output.declared_limits)
+    output.voltage_range = 1
+    output.enabled = True
+    output.voltage = 1.0
+    output.current = 0.2
+    assert output.read_output_status() == 'enabled:constant-voltage'
+
+    # Test current mode
+    print('Current mode')
+    output.mode = 'current'
+    assert not output.enabled
+    output.enabled = True
+    output.current_range = 0.2
+    output.voltage = 10
+    output.current = 0.1
+    assert output.read_output_status() == 'enabled:constant-voltage'


### PR DESCRIPTION
So far only the "standard" for DC power source is implemented and used for:
- Itest
  + BE2101: single output precision voltage source
  + BE2141: four outputs precision voltage source
- Yokogawa:
  + GS200
  + 7651 (we use the prefix Model since 7651 is not a valid class identifier in Python)
- Keysight/Agilent/HP:
  + E3631A (triple output DC power source +6/+25/-25 V, used in the lab to power amplifiers)
  + E3633A, E3634A (single outputs, not present in te lab and hence not tested).

@Exopy/owners I would appreciate if you can give this a look, hopefully the documentation (http://i3py.readthedocs.io/en/latest/?badge=latest) should be enough to understand the magic happening behind the scene. I would appreciate to get as much feedback as possible since this is the future for drivers.
I will work on implementing a generic task giving access to any feature/action of such a driver which will reduce the burden of developing super specific task for just setting a parameter.